### PR TITLE
fix(apps): pass content type to probes

### DIFF
--- a/app/service.go
+++ b/app/service.go
@@ -264,6 +264,12 @@ func httpProbe(path string) cv1.ProbeArgs {
 		HttpGet: cv1.HTTPGetActionArgs{
 			Path: pulumi.String(path),
 			Port: pulumi.Int(8080),
+			HttpHeaders: cv1.HTTPHeaderArray{
+				cv1.HTTPHeaderArgs{
+					Name:  pulumi.String("Content-Type"),
+					Value: pulumi.String("application/json"),
+				},
+			},
 		},
 		InitialDelaySeconds: pulumi.Int(5),
 		PeriodSeconds:       pulumi.Int(10),


### PR DESCRIPTION
As defined in https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request