### PR TITLE
build(ci): disable workflows until we have a fix for memory

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -356,6 +356,7 @@ jobs:
 
 workflows:
   infraops:
+    when: false
     jobs:
       - build
       - release:
@@ -381,7 +382,7 @@ workflows:
               only: master
 
   cf:
-    when: << pipeline.parameters.cf >>
+    when: false
     jobs:
       - cf_preview:
           context: infraops


### PR DESCRIPTION
https://til.codeinthehole.com/posts/how-to-easily-disable-a-circleci-workflow/
