### PR TITLE
docs(agents): document shared coding standards skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,25 @@
 # AGENTS.md
 
+## Shared skill
+
+Use the shared `coding-standards` skill from `./bin/skills/coding-standards`
+for cross-repository coding, review, testing, documentation, and PR
+conventions. Treat this `AGENTS.md` as the repo-specific companion to that
+skill.
+
 ## Repository overview
+
 This repository is a Go-based infra “monorepo” driven by **Pulumi** programs.
 
 Key concepts:
+
 - Each infrastructure “area” lives under `area/<name>/` and has a Pulumi entrypoint `area/<name>/main.go`.
 - Shared implementation lives under `internal/` (e.g. `internal/cf`, `internal/do`, `internal/gh`, `internal/app`).
 - Area configuration is stored as **HJSON** (e.g. `area/cf/cf.hjson`) and maps to protobuf types defined in `api/infraops/v2/service.proto`.
 - Package-level GoDocs are centralized in per-package `doc.go` files (not scattered across arbitrary `*.go` files).
 
 ## Quick orientation (where things live)
+
 - `area/`
   - `apps/`, `cf/`, `do/`, `gh/`: Pulumi programs (each has `Pulumi.yaml`, `*.hjson`, `main.go`, `main_test.go`).
   - `k8s/`: cluster add-ons installed via `helm`/`kubectl` (Makefile-driven).
@@ -29,10 +39,13 @@ Key concepts:
 - `bin/`: git submodule containing shared build tooling used by the top-level `Makefile`.
 
 ## Rule / instruction files
+
 No agent-specific rule files were found (e.g. `.cursor/rules`, `.cursorrules`, `CLAUDE.md`, `.github/copilot-instructions.md`).
 
 ## Essential commands (observed)
+
 ### Go deps, lint, tests, security
+
 From the repo root:
 
 ```bash
@@ -44,10 +57,12 @@ make sec          # govulncheck -test ./...
 ```
 
 Notes:
+
 - The `make specs` target runs tests with `-mod vendor` (see `bin/build/make/go.mak`). In CI, `make dep` runs before `make specs`.
 - Lint configuration is in `.golangci.yml`.
 
 ### API (protobuf / Buf)
+
 From the repo root:
 
 ```bash
@@ -68,10 +83,12 @@ Proto sources: `api/infraops/v2/service.proto`.
 Generated Go output: `api/infraops/v2/service.pb.go` (regenerate via `make api-generate` rather than editing).
 
 Notes:
+
 - Protobuf message/field comments are treated as part of the configuration contract and are kept detailed/implementation-accurate.
 - After modifying `service.proto`, regenerate code with `make api-generate` (or `make -C api generate`) and run tests.
 
 ### Pulumi (preview/update per area)
+
 From the repo root:
 
 ```bash
@@ -83,12 +100,14 @@ make area=<apps|cf|do|gh> pulumi-delete
 ```
 
 These targets run Pulumi with:
+
 - stack: `alexfalkowski/<area>/prod`
 - cwd: `area/<area>`
 
 (See `Makefile:10-27`.)
 
 ### Kubernetes add-ons (helm/kubectl)
+
 From `area/k8s/Makefile`:
 
 ```bash
@@ -99,10 +118,12 @@ make -C area/k8s pods
 ```
 
 This Makefile references environment variables:
+
 - `CIRCLECI_K8S_TOKEN` (used when installing the CircleCI release agent)
 - `BETTER_STACK_COLLECTOR_SECRET` (used when installing Better Stack)
 
 ### Applications area helpers
+
 From `area/apps/Makefile`:
 
 ```bash
@@ -116,6 +137,7 @@ make -C area/apps lint   # runs kube-score + kubescape
 ```
 
 ## Configuration format and flow
+
 - Config files are HJSON (e.g. `area/cf/cf.hjson`, `area/do/do.hjson`, `area/gh/gh.hjson`, `area/apps/apps.hjson`).
 - The schema is defined in `api/infraops/v2/service.proto`.
 - Config loading/writing is done via `internal/config.Read` / `internal/config.Write` (`internal/config/config.go`).
@@ -123,6 +145,7 @@ make -C area/apps lint   # runs kube-score + kubescape
   - `Write` preserves file mode (`os.Stat(...).Mode()`), marshals via `hjson.Marshal`, and appends a trailing newline.
 
 ### Config formatting tool
+
 Build and run:
 
 ```bash
@@ -133,6 +156,7 @@ make build-format
 - `-p` can override the path; default is `area/<kind>/<kind>.hjson` (see `cmd/format/format.go`).
 
 ### App version bump tool
+
 Build and run:
 
 ```bash
@@ -144,33 +168,42 @@ make build-bump
 - Implementation updates `config.GetApplications()[i].Version` (see `internal/app/version/version.go`).
 
 ## Code patterns and conventions
+
 ### Pulumi entrypoints
+
 Each area entrypoint follows the same pattern:
+
 - `pulumi.Run(func(ctx *pulumi.Context) error { ... })`
 - read `*.hjson` via `internal/<area>.ReadConfiguration`
 - convert protobuf types into internal types via `Convert*`
 - create resources via `Create*`
 
 Examples:
+
 - `area/apps/main.go`
 - `area/cf/main.go`
 - `area/do/main.go`
 - `area/gh/main.go`
 
 ### “Convert then Create”
+
 A typical flow is:
+
 - `ConvertX(*v2.X) *X`
 - `CreateX(ctx, *X) error`
 
 See:
+
 - `internal/gh/gh.go` (`ConvertRepository`, `CreateRepository`)
 - `internal/do/do.go` (`ConvertCluster`, `CreateCluster`)
 - `internal/app/app.go` (`ConvertApplication`, `CreateApplication`)
 
 ### Logging
+
 The CLI tools (`cmd/format`, `cmd/bump`) use `internal/log.NewLogger()` which returns a `slog` text logger writing to stdout.
 
 ### Testing
+
 - Uses `testify/require`.
 - Pulumi programs are tested with `pulumi.RunErr(..., pulumi.WithMocks(...))`.
 - Mocks are provided by `internal/test.Stub` and `internal/test.ErrStub`.
@@ -178,6 +211,7 @@ The CLI tools (`cmd/format`, `cmd/bump`) use `internal/log.NewLogger()` which re
 See `area/*/main_test.go` and `internal/test/stub.go`.
 
 ## Linting / formatting expectations
+
 - `.editorconfig` sets:
   - Go: tabs, size 4
   - Makefiles: tabs
@@ -185,6 +219,7 @@ See `area/*/main_test.go` and `internal/test/stub.go`.
 - `.golangci.yml` enables many linters and formatters; line length is configured via `lll` at 130.
 
 ## CI (CircleCI) behavior (observed)
+
 - `.circleci/config.yml` is a setup config using `circleci/path-filtering` to set pipeline parameters per area.
 - `.circleci/continue_config.yml` runs:
   - `build` (always): `make lint`, `make api-lint`, `make api-breaking`, `make sec`, `make specs`, `make coverage`, `make codecov-upload`.
@@ -195,6 +230,7 @@ See `area/*/main_test.go` and `internal/test/stub.go`.
 If reproducing locally, mirror the same Make targets used in CI.
 
 ## Gotchas / non-obvious behavior
+
 - **Cloudflare requires `CLOUDFLARE_ACCOUNT_ID`**: `internal/cf/cf.go` reads it from the environment (`os.Getenv`) and stores it as a package-level Pulumi string.
 - **Apps config maps read files relative to the Pulumi working directory**:
   - `internal/app/config.go` reads `<namespace>/<app>.yaml` using `os.Getwd()` + `filepath.Join(wd, ns, file)`.


### PR DESCRIPTION
## What
- Add a `Shared skill` section to [AGENTS.md](/Users/alejandro/code/alexfalkowski.github.io/AGENTS.md) telling agents to load `./bin/skills/coding-standards`.
- Clarify that `AGENTS.md` remains the repo-specific companion to the shared cross-repository guidance.

## Why
- Align this repo with the new shared skill so future coding, review, testing, documentation, and PR work follows the same baseline conventions.
- Keep shared guidance centralized in `./bin` while preserving repo-local instructions here.

## Testing
- Not run; this is a documentation-only change to agent instructions.