### PR TITLE
build(ci): wait for preview jobs before running sync

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -405,10 +405,7 @@ workflows:
   infraops:
     jobs:
       - build
-      - sync:
-          requires:
-            - build
-          filters: 'pipeline.git.branch != "master"'
+
       - version:
           context: gh
           serial-group: << pipeline.project.slug >>/version
@@ -443,6 +440,14 @@ workflows:
           serial-group: << pipeline.project.slug >>/gh
           context: infraops
           filters: 'pipeline.parameters.gh and pipeline.git.branch == "master"'
+      - sync:
+          requires:
+            - build
+            - apps_preview
+            - cf_preview
+            - do_preview
+            - gh_preview
+          filters: 'pipeline.git.branch != "master"'
       - wait-all:
           requires:
             - build


### PR DESCRIPTION
## What

Moves the `sync` job later in `.circleci/continue_config.yml` so it now runs after `build` and after the non-`master` preview jobs: `apps_preview`, `cf_preview`, `do_preview`, and `gh_preview`.

The branch filter for `sync` stays the same, so this only affects non-`master` workflow ordering. The `master` path through `version` and the `*_update` jobs is unchanged.

## Why

This makes the workflow sequencing explicit and prevents `sync` from running before the preview stage has finished on branch builds.

The change reduces the chance of CI side effects happening too early and makes the non-`master` pipeline reflect the intended flow: build first, preview applicable infra changes, then sync.

## Testing

No automated tests or lint checks were run for this request because it was a read-only summary task.

Reviewed the change directly with `git diff -- .circleci/continue_config.yml` and inspected the workflow block with `sed -n '392,470p' .circleci/continue_config.yml`.