### PR TITLE
docs(readme): clarify infra workflow assumptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,93 +1,40 @@
 # AGENTS.md
 
-## Shared skill
+## Baseline
 
-Use the shared `coding-standards` skill from `bin/skills/coding-standards` for code changes, bug fixes, refactors, reviews, tests, linting, documentation, PR summaries, commits, Makefile changes, CI validation, and verification. Treat this `AGENTS.md` as the repo-specific companion to that
-skill.
+- Use `bin/skills/coding-standards` for code changes, fixes, refactors, reviews, tests, linting, docs, PR summaries, commits, Makefile changes, CI validation, and verification.
+- This repo is a Go/Pulumi infra monorepo. Each Pulumi area lives in `area/<name>/` with `main.go`, `Pulumi.yaml`, and `<name>.hjson`.
+- Shared implementation lives in `internal/`; config schema lives in `api/infraops/v2/service.proto`; generated Go lives in `api/infraops/v2/service.pb.go`.
+- Keep package-level GoDocs in `doc.go` files. Do not scatter package comments across implementation files.
 
-## Repository overview
+## Layout
 
-This repository is a Go-based infra “monorepo” driven by **Pulumi** programs.
+- `area/apps`, `area/cf`, `area/do`, `area/gh`: Pulumi programs.
+- `area/k8s`: local `helm`/`kubectl` add-ons, not Pulumi and not CI.
+- `internal/app`, `internal/cf`, `internal/do`, `internal/gh`: provider/resource logic.
+- `internal/config`: HJSON read/write helpers for protobuf messages.
+- `internal/inputs`: shared Pulumi inputs.
+- `internal/test`: Pulumi mocks.
+- `cmd/bump`: internal app version bump helper.
+- `cmd/format`: HJSON config formatter.
+- `bin`: shared build tooling submodule.
 
-Key concepts:
+## Commands
 
-- Each infrastructure “area” lives under `area/<name>/` and has a Pulumi entrypoint `area/<name>/main.go`.
-- Shared implementation lives under `internal/` (e.g. `internal/cf`, `internal/do`, `internal/gh`, `internal/app`).
-- Area configuration is stored as **HJSON** (e.g. `area/cf/cf.hjson`) and maps to protobuf types defined in `api/infraops/v2/service.proto`.
-- Package-level GoDocs are centralized in per-package `doc.go` files (not scattered across arbitrary `*.go` files).
-
-## Quick orientation (where things live)
-
-- `area/`
-  - `apps/`, `cf/`, `do/`, `gh/`: Pulumi programs (each has `Pulumi.yaml`, `*.hjson`, `main.go`, `main_test.go`).
-  - `k8s/`: cluster add-ons installed via `helm`/`kubectl` (Makefile-driven).
-- `internal/`
-  - `app/`: Kubernetes application deployment logic (Pulumi Kubernetes resources).
-  - `cf/`: Cloudflare provisioning logic (Pulumi Cloudflare provider).
-  - `do/`: DigitalOcean provisioning logic (Pulumi DigitalOcean provider).
-  - `gh/`: GitHub provisioning logic (Pulumi GitHub provider).
-  - `config/`: HJSON read/write helpers for protobuf messages (`internal/config/config.go`).
-  - `inputs/`: shared Pulumi input constants (`internal/inputs/inputs.go`).
-  - `log/`: minimal slog logger used by CLI tools (`internal/log/log.go`).
-  - `test/`: Pulumi mocks used in unit tests (`internal/test/stub.go`).
-- `api/`: protobuf definitions + Buf config; Go codegen output is under `api/infraops/v2/`.
-- `cmd/`
-  - `bump/`: CLI to bump an app version in `area/apps/apps.hjson`.
-  - `format/`: CLI to normalize/format HJSON config files.
-- `bin/`: git submodule containing shared build tooling used by the top-level `Makefile`.
-
-## Rule / instruction files
-
-No agent-specific rule files were found (e.g. `.cursor/rules`, `.cursorrules`, `CLAUDE.md`, `.github/copilot-instructions.md`).
-
-## Essential commands (observed)
-
-### Go deps, lint, tests, security
-
-From the repo root:
+Run from the repo root unless noted:
 
 ```bash
-make dep          # go mod download/tidy/vendor (see bin/build/make/go.mak)
-make lint         # field-alignment + golangci-lint (uses bin submodule tooling)
-make specs        # gotestsum + go test (writes junit/coverage under test/reports)
-make coverage     # generates HTML + func coverage in test/reports
-make sec          # govulncheck -test ./...
-```
-
-Notes:
-
-- The `make specs` target runs tests with `-mod vendor` (see `bin/build/make/go.mak`). In CI, `make dep` runs before `make specs`.
-- Lint configuration is in `.golangci.yml`.
-
-### API (protobuf / Buf)
-
-From the repo root:
-
-```bash
+make dep
+make lint
+make specs
+make coverage
+make sec
 make api-lint
 make api-breaking
 make api-generate
 ```
 
-Or directly:
-
-```bash
-make -C api lint
-make -C api breaking
-make -C api generate
-```
-
-Proto sources: `api/infraops/v2/service.proto`.
-Generated Go output: `api/infraops/v2/service.pb.go` (regenerate via `make api-generate` rather than editing).
-
-Notes:
-
-- Protobuf message/field comments are treated as part of the configuration contract and are kept detailed/implementation-accurate.
-- After modifying `service.proto`, regenerate code with `make api-generate` (or `make -C api generate`) and run tests.
-
-### Pulumi (preview/update per area)
-
-From the repo root:
+Pulumi:
 
 ```bash
 make pulumi-login
@@ -97,16 +44,7 @@ make area=<apps|cf|do|gh> pulumi-cancel
 make area=<apps|cf|do|gh> pulumi-delete
 ```
 
-These targets run Pulumi with:
-
-- stack: `alexfalkowski/<area>/prod`
-- cwd: `area/<area>`
-
-(See `Makefile:10-27`.)
-
-### Kubernetes add-ons (helm/kubectl)
-
-From `area/k8s/Makefile`:
+Local Kubernetes add-ons:
 
 ```bash
 make -C area/k8s save-config
@@ -115,14 +53,7 @@ make -C area/k8s delete
 make -C area/k8s pods
 ```
 
-This Makefile references environment variables:
-
-- `CIRCLECI_K8S_TOKEN` (used when installing the CircleCI release agent)
-- `BETTER_STACK_COLLECTOR_SECRET` (used when installing Better Stack)
-
-### Applications area helpers
-
-From `area/apps/Makefile`:
+Application helpers:
 
 ```bash
 make -C area/apps save-config
@@ -131,117 +62,54 @@ make -C area/apps delete
 make -C area/apps rollout
 make -C area/apps verify
 make -C area/apps load
-make -C area/apps lint   # runs kube-score + kubescape
+make -C area/apps lint
 ```
 
-## Configuration format and flow
-
-- Config files are HJSON (e.g. `area/cf/cf.hjson`, `area/do/do.hjson`, `area/gh/gh.hjson`, `area/apps/apps.hjson`).
-- The schema is defined in `api/infraops/v2/service.proto`.
-- Config loading/writing is done via `internal/config.Read` / `internal/config.Write` (`internal/config/config.go`).
-  - `Read` uses `hjson.Unmarshal` into a protobuf message.
-  - `Write` preserves file mode (`os.Stat(...).Mode()`), marshals via `hjson.Marshal`, and appends a trailing newline.
-
-### Config formatting tool
-
-Build and run:
+Config tools:
 
 ```bash
 make build-format
 ./format -k <apps|cf|do|gh>
-```
 
-- `-p` can override the path; default is `area/<kind>/<kind>.hjson` (see `cmd/format/format.go`).
-
-### App version bump tool
-
-Build and run:
-
-```bash
 make build-bump
 ./bump -n <appName> -v <version>
 ```
 
-- `-p` can override the path; default is `area/apps/apps.hjson` (see `cmd/bump/bump.go`).
-- Implementation updates `config.GetApplications()[i].Version` (see `internal/app/version/version.go`).
+## Workflow Rules
 
-## Code patterns and conventions
+- Run `make dep` before validation unless the task is strictly read-only.
+- Use repository Make targets over ad hoc commands when they cover the task.
+- After editing `api/infraops/v2/service.proto`, run `make api-generate` and include `service.pb.go`.
+- Do not hand-edit generated code unless explicitly asked.
+- Keep config comments in `service.proto` accurate; they are part of the HJSON configuration contract.
+- Tests use `testify/require`; Pulumi tests use `pulumi.RunErr(..., pulumi.WithMocks(...))`.
+- Use `internal/test.Stub` and `internal/test.ErrStub` for Pulumi mocks.
+- Lint config is `.golangci.yml`; editor defaults are in `.editorconfig`.
 
-### Pulumi entrypoints
+## Code Patterns
 
-Each area entrypoint follows the same pattern:
+- Pulumi entrypoints follow: read HJSON, convert protobuf model, create resources.
+- Conversion/resource pattern: `ConvertX(*v2.X) *X`, then `CreateX(ctx, *X) error`.
+- CLI tools use `internal/log.NewLogger()`.
+- `internal/config.Read` uses HJSON unmarshal into protobuf messages.
+- `internal/config.Write` preserves destination file mode and appends a trailing newline.
 
-- `pulumi.Run(func(ctx *pulumi.Context) error { ... })`
-- read `*.hjson` via `internal/<area>.ReadConfiguration`
-- convert protobuf types into internal types via `Convert*`
-- create resources via `Create*`
+## Intentional Assumptions
 
-Examples:
+- `cmd/bump` is an internal automation helper. `-v` is expected to be a semantic version supplied by automation.
+- `area/k8s/Makefile` is for manual operator workstation runs, not CI. `CIRCLECI_K8S_TOKEN` is passed directly to Helm in that local workflow.
+- GitHub branch protection intentionally requires zero approving PR reviews because this is a solo-maintainer workflow; required status checks are the primary merge gate.
+- Apps `NetworkPolicy` resources intentionally select app pods but allow all ingress and egress until per-app traffic flows are modeled. Do not tighten generically without checking DNS, ingress, probes, telemetry, and outbound service calls.
+- Apps env var secret references use `secret:<secretName>/<key>` and become Kubernetes `SecretKeyRef`s with Secret name `<secretName>-secret` and key `<key>`. The helper code does not pre-validate the shape; malformed references fail during Pulumi/Kubernetes application.
+- `Application.secrets` is an app-level dependency list; secret env vars reference specific keys. Keep this behavior aligned with `service.proto`.
+- `Application.resource` falls back to `"small"` for unknown values. Current small profile: cpu `125m-250m`, memory `64Mi-128Mi`, ephemeral-storage `1Gi-2Gi`.
+- Cloudflare resources require `CLOUDFLARE_ACCOUNT_ID`; `internal/cf/cf.go` reads it at package scope.
+- Apps config maps read `<namespace>/<app>.yaml` relative to the Pulumi working directory. The root Makefile runs Pulumi with `--cwd area/apps`.
+- GitHub Pages and collaborators may need to be disabled on first repository creation and enabled in a follow-up change.
 
-- `area/apps/main.go`
-- `area/cf/main.go`
-- `area/do/main.go`
-- `area/gh/main.go`
+## CI
 
-### “Convert then Create”
-
-A typical flow is:
-
-- `ConvertX(*v2.X) *X`
-- `CreateX(ctx, *X) error`
-
-See:
-
-- `internal/gh/gh.go` (`ConvertRepository`, `CreateRepository`)
-- `internal/do/do.go` (`ConvertCluster`, `CreateCluster`)
-- `internal/app/app.go` (`ConvertApplication`, `CreateApplication`)
-
-### Logging
-
-The CLI tools (`cmd/format`, `cmd/bump`) use `internal/log.NewLogger()` which returns a `slog` text logger writing to stdout.
-
-### Testing
-
-- Uses `testify/require`.
-- Pulumi programs are tested with `pulumi.RunErr(..., pulumi.WithMocks(...))`.
-- Mocks are provided by `internal/test.Stub` and `internal/test.ErrStub`.
-
-See `area/*/main_test.go` and `internal/test/stub.go`.
-
-## Linting / formatting expectations
-
-- `.editorconfig` sets:
-  - Go: tabs, size 4
-  - Makefiles: tabs
-  - General text: spaces, size 2
-- `.golangci.yml` enables many linters and formatters; line length is configured via `lll` at 130.
-
-## CI (CircleCI) behavior (observed)
-
-- `.circleci/config.yml` is a setup config using `circleci/path-filtering` to set pipeline parameters per area.
-- `.circleci/continue_config.yml` runs:
-  - `build` (always): `make lint`, `make api-lint`, `make api-breaking`, `make sec`, `make specs`, `make coverage`, `make codecov-upload`.
-  - per-area workflows:
-    - `*_preview` runs on non-`master` branches (Pulumi preview).
-    - `*_update` runs only on `master` (Pulumi update), plus extra steps for `apps` (`verify`, `load`, `lint`).
-
-If reproducing locally, mirror the same Make targets used in CI.
-
-## Gotchas / non-obvious behavior
-
-- **Cloudflare requires `CLOUDFLARE_ACCOUNT_ID`**: `internal/cf/cf.go` reads it from the environment (`os.Getenv`) and stores it as a package-level Pulumi string.
-- **Apps config maps read files relative to the Pulumi working directory**:
-  - `internal/app/config.go` reads `<namespace>/<app>.yaml` using `os.Getwd()` + `filepath.Join(wd, ns, file)`.
-  - When running Pulumi via `make area=apps pulumi-*`, Pulumi runs with `--cwd area/apps`, so ensure the expected files exist under `area/apps/<namespace>/`.
-- **Apps env var secret references**:
-  - `EnvVar.value` supports the convention `secret:<secretName>/<key>`.
-  - At deploy time this is converted into a Kubernetes `SecretKeyRef` with Secret name `<secretName>-secret` and key `<key>` (see `internal/app/environment.go` and `internal/app/secret.go`).
-- **`Application.secrets` vs secret env vars**:
-  - `Application.secrets` is an application-level dependency list used by the deployment implementation to provision and/or wire Secret resources (for example volumes/attachments).
-  - Secret references in `env_vars` (`secret:<secretName>/<key>`) target specific keys; the `secrets` list does not specify keys.
-  - These behaviors are documented in `api/infraops/v2/service.proto` and should be kept in sync with implementation.
-- **Apps resource sizing**:
-  - `Application.resource` selects a resource profile; unknown values fall back to `"small"` (see `internal/app/resource.go`).
-  - Current mapping includes `"small"`: cpu 125m-250m, memory 64Mi-128Mi, ephemeral-storage 1Gi-2Gi.
-- **GitHub repository creation has a 2-step process for some features** (from `README.md`):
-  - Pages and collaborators may need to be disabled on first creation and enabled in a follow-up change to avoid timing issues.
+- CircleCI setup config uses path filtering to enable area workflows.
+- The main `build` job runs `make lint`, `make api-lint`, `make api-breaking`, `make sec`, `make specs`, `make coverage`, and Codecov upload.
+- Area preview jobs run on non-`master`; update jobs run only on `master`.
+- Apps updates also run `make -C area/apps verify`, `load`, and `lint`.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ At deploy time, this becomes a Kubernetes `SecretKeyRef`:
 - Secret name: `<secretName>-secret`
 - Secret key: `<key>`
 
+The format is intentionally not pre-validated by the helper code; malformed references are expected
+to fail during Pulumi/Kubernetes application.
+
 Example:
 
 ```hjson
@@ -102,6 +105,14 @@ env_vars: [
 - `"small"` (default): cpu `125m-250m`, memory `64Mi-128Mi`, ephemeral-storage `1Gi-2Gi`
 
 Unknown values fall back to `"small"`.
+
+#### App NetworkPolicy baseline
+
+The apps Pulumi program creates a `NetworkPolicy` that selects each app's pods but currently allows
+all ingress and egress. This is intentional: the required traffic flows are not modeled per app yet,
+and tightening the policy generically could break DNS, ingress, health checks, telemetry, or outbound
+service calls. Future restrictions should be introduced per namespace/app after the required flows
+are known.
 
 ## Common workflows
 
@@ -194,7 +205,8 @@ Build:
 make build-bump
 ```
 
-Update a single app version in config:
+Update a single app version in config. This is an internal helper used by automation, and the
+`-v` value is expected to be a semantic version:
 
 ```bash
 ./bump -n bezeichner -v 1.559.0
@@ -322,6 +334,7 @@ If the pipeline fails due to timing, a rerun often succeeds.
 ### Kubernetes add-ons (`area/k8s`)
 
 This is not a Pulumi area. It contains cluster add-ons installed via `helm`/`kubectl`.
+These targets are intended to be run manually from an operator workstation, not from CI.
 
 > [!CAUTION]
 > Run this only after you have a Kubernetes cluster (for example from `area/do`).
@@ -350,6 +363,9 @@ Depending on what you install, the k8s add-ons Makefile expects secrets like:
 
 - `CIRCLECI_K8S_TOKEN` (CircleCI release agent)
 - `BETTER_STACK_COLLECTOR_SECRET` (Better Stack collector)
+
+Because the Makefile is a local-operator workflow, the CircleCI release-agent token is passed
+directly to Helm rather than through a CI secret-handling path.
 
 ## Repository structure
 

--- a/api/infraops/v2/service.pb.go
+++ b/api/infraops/v2/service.pb.go
@@ -42,6 +42,8 @@ const (
 //   - "secret:<secretName>/<key>"
 //
 // The Kubernetes Secret name used by the implementation is "<secretName>-secret" and the key is <key>.
+// The implementation intentionally does not pre-validate this shape; malformed references fail
+// during Pulumi/Kubernetes application.
 type EnvVar struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Name is the environment variable name (for example "LOG_LEVEL").
@@ -478,6 +480,8 @@ type Repository struct {
 	// Topics is the set of repository topics to apply.
 	Topics []string `protobuf:"bytes,10,rep,name=topics,proto3" json:"topics,omitempty"`
 	// Checks is the set of required status check contexts enforced by branch protection.
+	// Branch protection intentionally requires zero approving PR reviews because these repositories
+	// are maintained by a solo contributor, so required status checks are the primary merge gate.
 	//
 	// In the current implementation, an empty list is invalid and will cause provisioning to fail.
 	Checks        []string `protobuf:"bytes,11,rep,name=checks,proto3" json:"checks,omitempty"`

--- a/api/infraops/v2/service.proto
+++ b/api/infraops/v2/service.proto
@@ -24,6 +24,8 @@ option go_package = "github.com/alexfalkowski/infraops/v2/api/infraops/v2";
 //   - "secret:<secretName>/<key>"
 //
 // The Kubernetes Secret name used by the implementation is "<secretName>-secret" and the key is <key>.
+// The implementation intentionally does not pre-validate this shape; malformed references fail
+// during Pulumi/Kubernetes application.
 message EnvVar {
   // Name is the environment variable name (for example "LOG_LEVEL").
   string name = 1;
@@ -157,6 +159,8 @@ message Repository {
   repeated string topics = 10;
 
   // Checks is the set of required status check contexts enforced by branch protection.
+  // Branch protection intentionally requires zero approving PR reviews because these repositories
+  // are maintained by a solo contributor, so required status checks are the primary merge gate.
   //
   // In the current implementation, an empty list is invalid and will cause provisioning to fail.
   repeated string checks = 11;

--- a/area/k8s/Makefile
+++ b/area/k8s/Makefile
@@ -16,7 +16,7 @@ setup-helm:
 	@helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
 	@helm repo update
 
-# Install circleci.
+# Install circleci. This target is run manually from an operator workstation, not CI.
 install-circleci:
 	@helm upgrade --install circleci-release circleci/circleci-release-agent --set tokenSecret.token=$(CIRCLECI_K8S_TOKEN) --create-namespace --namespace circleci --set managedNamespaces="{lean}" --version 1.5.0
 

--- a/cmd/bump/bump.go
+++ b/cmd/bump/bump.go
@@ -1,6 +1,8 @@
 // Command bump updates an application's version inside the apps configuration file.
 //
 // By default it edits `area/apps/apps.hjson`, but you can override the location via `-p`.
+// The tool is intended for internal automation and expects `-v` to be a semantic version string
+// supplied by that automation.
 //
 // Usage:
 //

--- a/internal/app/network.go
+++ b/internal/app/network.go
@@ -11,6 +11,7 @@ func createNetworkPolicy(ctx *pulumi.Context, app *App) error {
 		Metadata: metadata(app),
 		Spec: nv1.NetworkPolicySpecArgs{
 			PodSelector: mv1.LabelSelectorArgs{MatchLabels: matchLabels(app)},
+			// The policy selects app pods, but allows all traffic until per-app flows are modeled.
 			Ingress: nv1.NetworkPolicyIngressRuleArray{
 				nv1.NetworkPolicyIngressRuleArgs{},
 			},

--- a/internal/gh/protection.go
+++ b/internal/gh/protection.go
@@ -10,7 +10,7 @@ import (
 //
 // It enforces:
 //   - linear history
-//   - pull request reviews (with stale reviews dismissed)
+//   - pull request review settings with zero required approvals, matching the solo-maintainer workflow
 //   - required status checks as specified by repo.Checks (strict mode enabled)
 //
 // The branch name is taken from the package-level master constant.


### PR DESCRIPTION
## What

- Document the solo-maintainer branch protection policy with zero required PR approvals.
- Clarify that the bump tool expects semantic versions from internal automation.
- Document that secret env var references are not pre-validated and fail during Pulumi/Kubernetes apply if malformed.
- Mark the k8s add-ons Makefile as a local operator workflow, not CI.
- Document the current app NetworkPolicy baseline as intentionally allowing all ingress and egress until per-app traffic flows are modeled.
- Regenerate protobuf Go docs from the updated schema comments.

## Why

These notes make the repository’s intentional operational assumptions explicit, so future audits do not treat them as accidental gaps or risky omissions.

## Testing

- `make api-generate`
- `make api-lint`
- `go test ./internal/gh`
- `go test ./cmd/bump ./internal/app/version`
- `go test ./internal/app`

Validation was scoped to the documentation/code-comment changes and the affected generated protobuf docs.