### PR TITLE
feat(gh): preserve incomplete template validation

### DIFF
--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -87,14 +87,9 @@ func ConvertRepository(r *v2.Repository) *Repository {
 	}
 
 	if template := r.GetTemplate(); template != nil {
-		owner := template.GetOwner()
-		repo := template.GetRepository()
-
-		if owner != "" && repo != "" {
-			repository.Template = &Template{
-				Owner:      owner,
-				Repository: repo,
-			}
+		repository.Template = &Template{
+			Owner:      template.GetOwner(),
+			Repository: template.GetRepository(),
 		}
 	}
 

--- a/internal/gh/gh_test.go
+++ b/internal/gh/gh_test.go
@@ -3,6 +3,7 @@ package gh_test
 import (
 	"testing"
 
+	v2 "github.com/alexfalkowski/infraops/v2/api/infraops/v2"
 	"github.com/alexfalkowski/infraops/v2/internal/gh"
 	"github.com/alexfalkowski/infraops/v2/internal/test"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -63,4 +64,23 @@ func TestCreateRepository(t *testing.T) {
 		return nil
 	}, pulumi.WithMocks("project", "stack", &test.ErrStub{}))
 	require.Error(t, err)
+}
+
+func TestCreateRepositoryFromIncompleteTemplateConfig(t *testing.T) {
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		a := gh.ConvertRepository(&v2.Repository{
+			Name:        "test",
+			Description: "test",
+			HomepageUrl: "https://alexfalkowski.github.io/test",
+			Template:    &v2.Template{Owner: "alexfalkowski"},
+			Checks:      []string{"ci/circleci: build"},
+		})
+
+		require.NotNil(t, a.Template)
+		err := gh.CreateRepository(ctx, a)
+		require.ErrorIs(t, err, gh.ErrMissingTemplate)
+
+		return nil
+	}, pulumi.WithMocks("project", "stack", &test.Stub{}))
+	require.NoError(t, err)
 }


### PR DESCRIPTION
## What

- Preserve explicit repository template config during protobuf conversion even when fields are incomplete.
- Add regression coverage proving incomplete converted template config returns ErrMissingTemplate.

## Why

- Avoid silently provisioning repositories without the requested template when config has a partial template block.

## Testing

- make dep
- go test ./internal/gh ./area/gh
- make specs
- make lint

AI-assisted-by: [Codex](https://openai.com/codex/)
