### PR TITLE
feat(app): set service protocol metadata

### DIFF
--- a/area/apps/doc.go
+++ b/area/apps/doc.go
@@ -1,0 +1,9 @@
+// Command apps is the Pulumi program for managing Kubernetes applications deployed by this repository.
+//
+// It reads `apps.hjson` from the current working directory (the Pulumi project directory) and
+// provisions Kubernetes resources (for example Deployments, Services, Ingresses, and related
+// supporting resources) for each application described in the config.
+//
+// This program is typically executed via the repository Makefile targets, which run Pulumi
+// with `--cwd area/apps`, ensuring `apps.hjson` is resolved relative to that directory.
+package main

--- a/area/apps/main.go
+++ b/area/apps/main.go
@@ -1,11 +1,3 @@
-// Command apps is the Pulumi program for managing Kubernetes applications deployed by this repository.
-//
-// It reads `apps.hjson` from the current working directory (the Pulumi project directory) and
-// provisions Kubernetes resources (for example Deployments, Services, Ingresses, and related
-// supporting resources) for each application described in the config.
-//
-// This program is typically executed via the repository Makefile targets, which run Pulumi
-// with `--cwd area/apps`, ensuring `apps.hjson` is resolved relative to that directory.
 package main
 
 import (

--- a/area/cf/doc.go
+++ b/area/cf/doc.go
@@ -1,0 +1,9 @@
+// Command cf is the Pulumi program for managing Cloudflare infrastructure for this repository.
+//
+// It reads `cf.hjson` from the current working directory (the Pulumi project directory) and
+// provisions Cloudflare resources (for example zones, DNS records, and R2 buckets/custom domains)
+// as described by the config.
+//
+// This program is typically executed via the repository Makefile targets, which run Pulumi
+// with `--cwd area/cf`, ensuring `cf.hjson` is resolved relative to that directory.
+package main

--- a/area/cf/main.go
+++ b/area/cf/main.go
@@ -1,11 +1,3 @@
-// Command cf is the Pulumi program for managing Cloudflare infrastructure for this repository.
-//
-// It reads `cf.hjson` from the current working directory (the Pulumi project directory) and
-// provisions Cloudflare resources (for example zones, DNS records, and R2 buckets/custom domains)
-// as described by the config.
-//
-// This program is typically executed via the repository Makefile targets, which run Pulumi
-// with `--cwd area/cf`, ensuring `cf.hjson` is resolved relative to that directory.
 package main
 
 import (

--- a/area/do/doc.go
+++ b/area/do/doc.go
@@ -1,0 +1,9 @@
+// Command do is the Pulumi program for managing DigitalOcean infrastructure for this repository.
+//
+// It reads `do.hjson` from the current working directory (the Pulumi project directory) and
+// provisions DigitalOcean resources (for example VPCs and Kubernetes clusters) as described by
+// the config.
+//
+// This program is typically executed via the repository Makefile targets, which run Pulumi
+// with `--cwd area/do`, ensuring `do.hjson` is resolved relative to that directory.
+package main

--- a/area/do/main.go
+++ b/area/do/main.go
@@ -1,11 +1,3 @@
-// Command do is the Pulumi program for managing DigitalOcean infrastructure for this repository.
-//
-// It reads `do.hjson` from the current working directory (the Pulumi project directory) and
-// provisions DigitalOcean resources (for example VPCs and Kubernetes clusters) as described by
-// the config.
-//
-// This program is typically executed via the repository Makefile targets, which run Pulumi
-// with `--cwd area/do`, ensuring `do.hjson` is resolved relative to that directory.
 package main
 
 import (

--- a/area/gh/doc.go
+++ b/area/gh/doc.go
@@ -1,0 +1,9 @@
+// Command gh is the Pulumi program for managing GitHub infrastructure for this repository.
+//
+// It reads `gh.hjson` from the current working directory (the Pulumi project directory)
+// and provisions GitHub repositories and their associated configuration (for example branch
+// protection, collaborators, and Pages) as described by the config.
+//
+// This program is typically executed via the repository Makefile targets, which run Pulumi
+// with `--cwd area/gh`, ensuring `gh.hjson` is resolved relative to that directory.
+package main

--- a/area/gh/main.go
+++ b/area/gh/main.go
@@ -1,11 +1,3 @@
-// Command gh is the Pulumi program for managing GitHub infrastructure for this repository.
-//
-// It reads `gh.hjson` from the current working directory (the Pulumi project directory)
-// and provisions GitHub repositories and their associated configuration (for example branch
-// protection, collaborators, and Pages) as described by the config.
-//
-// This program is typically executed via the repository Makefile targets, which run Pulumi
-// with `--cwd area/gh`, ensuring `gh.hjson` is resolved relative to that directory.
 package main
 
 import (

--- a/cmd/bump/bump.go
+++ b/cmd/bump/bump.go
@@ -1,14 +1,3 @@
-// Command bump updates an application's version inside the apps configuration file.
-//
-// By default it edits `area/apps/apps.hjson`, but you can override the location via `-p`.
-// The tool is intended for internal automation and expects `-v` to be a semantic version string
-// supplied by that automation.
-//
-// Usage:
-//
-//	bump -n <appName> -v <version> [-p <path>]
-//
-// Exit status is non-zero on error.
 package main
 
 import (

--- a/cmd/bump/doc.go
+++ b/cmd/bump/doc.go
@@ -1,0 +1,12 @@
+// Command bump updates an application's version inside the apps configuration file.
+//
+// By default it edits `area/apps/apps.hjson`, but you can override the location via `-p`.
+// The tool is intended for internal automation and expects `-v` to be a semantic version string
+// supplied by that automation.
+//
+// Usage:
+//
+//	bump -n <appName> -v <version> [-p <path>]
+//
+// Exit status is non-zero on error.
+package main

--- a/cmd/format/doc.go
+++ b/cmd/format/doc.go
@@ -1,0 +1,11 @@
+// Command format normalizes/rewrites an area configuration file in a consistent HJSON form.
+//
+// It reads a configuration into the corresponding protobuf message and writes it back out
+// using the repository's canonical HJSON formatting rules.
+//
+// Usage:
+//
+//	format -k <apps|cf|do|gh> [-p <path>]
+//
+// By default, the path is `area/<kind>/<kind>.hjson`.
+package main

--- a/cmd/format/format.go
+++ b/cmd/format/format.go
@@ -1,13 +1,3 @@
-// Command format normalizes/rewrites an area configuration file in a consistent HJSON form.
-//
-// It reads a configuration into the corresponding protobuf message and writes it back out
-// using the repository's canonical HJSON formatting rules.
-//
-// Usage:
-//
-//	format -k <apps|cf|do|gh> [-p <path>]
-//
-// By default, the path is `area/<kind>/<kind>.hjson`.
 package main
 
 import (

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -28,6 +28,7 @@ func TestApp(t *testing.T) {
 
 			require.NoError(t, pulumi.RunErr(run, pulumi.WithMocks("project", "stack", stub)))
 			require.Equal(t, portNumbers(app.Ports(tt.app)), networkPolicyIngressPorts(stub.networkPolicy))
+			require.Equal(t, portProtocols(app.Ports(tt.app)), servicePortAppProtocols(stub.service))
 		})
 	}
 
@@ -49,11 +50,15 @@ type resourceStub struct {
 	test.Stub
 
 	networkPolicy resource.PropertyMap
+	service       resource.PropertyMap
 }
 
 func (s *resourceStub) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
 	if args.TypeToken == "kubernetes:networking.k8s.io/v1:NetworkPolicy" {
 		s.networkPolicy = args.Inputs
+	}
+	if args.TypeToken == "kubernetes:core/v1:Service" {
+		s.service = args.Inputs
 	}
 
 	return s.Stub.NewResource(args)
@@ -102,6 +107,15 @@ func portNumbers(ports []app.Port) []int {
 	return numbers
 }
 
+func portProtocols(ports []app.Port) []string {
+	protocols := make([]string, 0, len(ports))
+	for _, port := range ports {
+		protocols = append(protocols, port.Protocol)
+	}
+
+	return protocols
+}
+
 func networkPolicyIngressPorts(policy resource.PropertyMap) []int {
 	spec := policy[resource.PropertyKey("spec")].ObjectValue()
 	ingress := spec[resource.PropertyKey("ingress")].ArrayValue()
@@ -111,6 +125,19 @@ func networkPolicyIngressPorts(policy resource.PropertyMap) []int {
 	for _, port := range ports {
 		value := port.ObjectValue()[resource.PropertyKey("port")].NumberValue()
 		values = append(values, int(value))
+	}
+
+	return values
+}
+
+func servicePortAppProtocols(service resource.PropertyMap) []string {
+	spec := service[resource.PropertyKey("spec")].ObjectValue()
+	ports := spec[resource.PropertyKey("ports")].ArrayValue()
+
+	values := make([]string, 0, len(ports))
+	for _, port := range ports {
+		value := port.ObjectValue()[resource.PropertyKey("appProtocol")].StringValue()
+		values = append(values, value)
 	}
 
 	return values

--- a/internal/app/network.go
+++ b/internal/app/network.go
@@ -68,7 +68,7 @@ func httpIngressRule(app *App) nv1.HTTPIngressRuleValueArgs {
 				Backend: nv1.IngressBackendArgs{
 					Service: nv1.IngressServiceBackendArgs{
 						Name: pulumi.String(app.Name),
-						Port: nv1.ServiceBackendPortArgs{Number: pulumi.Int(httpPort)},
+						Port: nv1.ServiceBackendPortArgs{Number: pulumi.Int(8080)},
 					},
 				},
 			},

--- a/internal/app/port.go
+++ b/internal/app/port.go
@@ -5,19 +5,12 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-const (
-	debugPortName = "debug"
-	debugPort     = 6060
-	httpPortName  = "http"
-	httpPort      = 8080
-	grpcPortName  = "grpc"
-	grpcPort      = 9090
-)
-
 // Port describes an application port exposed by Kubernetes resources.
 type Port struct {
 	// Name is the stable Kubernetes service port name.
 	Name string
+	// Protocol is the application protocol exposed on the service port.
+	Protocol string
 	// Number is the TCP port number used by the container and service.
 	Number int
 }
@@ -26,13 +19,13 @@ type Port struct {
 func Ports(app *App) []Port {
 	if app.IsInternal() {
 		return []Port{
-			{Name: debugPortName, Number: debugPort},
-			{Name: httpPortName, Number: httpPort},
-			{Name: grpcPortName, Number: grpcPort},
+			{Name: "debug", Number: 6060, Protocol: "http"},
+			{Name: "http", Number: 8080, Protocol: "http"},
+			{Name: "grpc", Number: 9090, Protocol: "grpc"},
 		}
 	}
 
-	return []Port{{Name: httpPortName, Number: httpPort}}
+	return []Port{{Name: "http", Number: 8080, Protocol: "http"}}
 }
 
 func containerPorts(app *App) cv1.ContainerPortArray {
@@ -57,9 +50,10 @@ func servicePorts(app *App) cv1.ServicePortArray {
 
 func servicePort(port Port) cv1.ServicePortArgs {
 	return cv1.ServicePortArgs{
-		AppProtocol: pulumi.String("TCP"),
+		AppProtocol: pulumi.String(port.Protocol),
 		Name:        pulumi.String(port.Name),
 		Port:        pulumi.Int(port.Number),
+		Protocol:    pulumi.String("TCP"),
 		TargetPort:  pulumi.Int(port.Number),
 	}
 }

--- a/internal/app/probe.go
+++ b/internal/app/probe.go
@@ -11,7 +11,7 @@ func httpProbe(path string) cv1.ProbeArgs {
 	return cv1.ProbeArgs{
 		HttpGet: cv1.HTTPGetActionArgs{
 			Path: pulumi.String(path),
-			Port: pulumi.Int(httpPort),
+			Port: pulumi.Int(8080),
 		},
 		InitialDelaySeconds: pulumi.Int(5),
 		PeriodSeconds:       pulumi.Int(10),
@@ -24,7 +24,7 @@ func httpProbe(path string) cv1.ProbeArgs {
 func tcpProbe() cv1.ProbeArgs {
 	return cv1.ProbeArgs{
 		TcpSocket: cv1.TCPSocketActionArgs{
-			Port: pulumi.Int(httpPort),
+			Port: pulumi.Int(8080),
 		},
 		InitialDelaySeconds:           pulumi.Int(5),
 		PeriodSeconds:                 pulumi.Int(10),


### PR DESCRIPTION
## What

- Set Kubernetes Service ports with explicit TCP transport protocol and application protocol hints.
- Add mock coverage for generated service appProtocol values.
- Move command package documentation into doc.go files.

## Why

- Make port semantics clearer for Kubernetes consumers while keeping package documentation in the repo-preferred location.

## Testing

- make dep
- go test ./area/apps ./area/cf ./area/do ./area/gh ./cmd/bump ./cmd/format ./internal/app
- make lint (passes with the existing gomodguard deprecation warning)
- make specs

AI-assisted-by: [Codex](https://openai.com/codex/)
