### PR TITLE
feat(apps): drop lean transport retry overrides

### DIFF
--- a/area/apps/lean/bezeichner.yaml
+++ b/area/apps/lean/bezeichner.yaml
@@ -30,18 +30,10 @@ transport:
       kind: user-agent
       tokens: 1000
       interval: 1s
-    retry:
-      attempts: 3
-      backoff: 100ms
-      timeout: 3s
     timeout: 5s
   grpc:
     limiter:
       kind: user-agent
       tokens: 1000
       interval: 1s
-    retry:
-      attempts: 3
-      backoff: 100ms
-      timeout: 3s
     timeout: 5s

--- a/area/apps/lean/standort.yaml
+++ b/area/apps/lean/standort.yaml
@@ -14,18 +14,10 @@ transport:
       kind: user-agent
       tokens: 1000
       interval: 1s
-    retry:
-      attempts: 3
-      backoff: 100ms
-      timeout: 3s
     timeout: 5s
   grpc:
     limiter:
       kind: user-agent
       tokens: 1000
       interval: 1s
-    retry:
-      attempts: 3
-      backoff: 100ms
-      timeout: 3s
     timeout: 5s

--- a/area/apps/lean/web.yaml
+++ b/area/apps/lean/web.yaml
@@ -14,8 +14,4 @@ transport:
       kind: user-agent
       tokens: 1000
       interval: 1s
-    retry:
-      attempts: 3
-      backoff: 100ms
-      timeout: 3s
     timeout: 5s


### PR DESCRIPTION
## What

- Remove explicit HTTP/gRPC retry settings from lean bezeichner and standort config.
- Remove the explicit HTTP retry setting from lean web config.

## Why

- Let the lean services run without per-transport retry overrides while preserving existing limiter and timeout settings.

## Testing

- make dep
- make specs
- make lint
