### PR TITLE
test(feature): cover pulumi resource inputs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,21 +11,25 @@ workflows:
       - path_filtering/filter:
           mapping: |
             .circleci/.* gh true
+            Makefile gh true
             area/gh/.* gh true
             internal/gh/.* gh true
             go.* gh true
 
             .circleci/.* cf true
+            Makefile cf true
             area/cf/.* cf true
             internal/cf/.* cf true
             go.* cf true
 
             .circleci/.* do true
+            Makefile do true
             area/do/.* do true
             internal/do/.* do true
             go.* do true
 
             .circleci/.* apps true
+            Makefile apps true
             area/apps/.* apps true
             internal/app/.* apps true
             go.* apps true

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -56,6 +56,8 @@ jobs:
           key: infraops-build-go-lint-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-lint-version" }}-{{ checksum ".source-key" }}
           paths:
             - ~/.cache/golangci-lint
+      - run: make build-bump
+      - run: make build-format
       - run: make api-lint
       - run: make api-breaking
       - run: make sec

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage.html
 *.bin
 /bump
 /format
+ISSUES.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ make build-bump
 - Do not hand-edit generated code unless explicitly asked.
 - Keep config comments in `service.proto` accurate; they are part of the HJSON configuration contract.
 - Tests use `testify/require`; Pulumi tests use `pulumi.RunErr(..., pulumi.WithMocks(...))`.
-- Use `internal/test.Stub` and `internal/test.ErrStub` for Pulumi mocks.
+- Use `internal/test.Stub` and `internal/test.ResourceStub` for Pulumi mocks.
 - Lint config is `.golangci.yml`; editor defaults are in `.editorconfig`.
 
 ## Code Patterns
@@ -101,7 +101,8 @@ make build-bump
 
 ## Intentional Assumptions
 
-- `cmd/bump` is an internal automation helper. `-v` is expected to be a semantic version supplied by automation.
+- `cmd/bump` is an internal automation helper. `-v` is expected to be a semantic version supplied by automation. Its CLI behavior is verified in other testing environments; do not report missing in-repo command-level `cmd/bump` CLI tests as a test gap.
+- `cmd/format` CLI behavior is verified in other testing environments; do not report missing in-repo command-level `cmd/format` CLI tests as a test gap.
 - `area/k8s/Makefile` is for manual operator workstation runs, not CI. `CIRCLECI_K8S_TOKEN` is passed directly to Helm in that local workflow.
 - GitHub branch protection intentionally requires zero approving PR reviews because this is a solo-maintainer workflow; required status checks are the primary merge gate.
 - Apps `NetworkPolicy` resources select app pods, limit ingress to app ports, and intentionally keep egress open until per-app traffic flows are modeled. Do not tighten egress generically without checking DNS, ingress, probes, telemetry, and outbound service calls.
@@ -111,6 +112,8 @@ make build-bump
 - Cloudflare resources require `CLOUDFLARE_ACCOUNT_ID`; `internal/cf/cf.go` reads it at package scope.
 - Apps config maps read `<namespace>/<app>.yaml` relative to the Pulumi working directory. The root Makefile runs Pulumi with `--cwd area/apps`.
 - GitHub Pages and collaborators may need to be disabled on first repository creation and enabled in a follow-up change.
+- Direct tests for `internal/config.Write` preserving file mode and appending a trailing newline are considered overkill; do not report that narrow helper behavior as a standalone test gap.
+- `make api-breaking` is the intended API schema guard in CI. Do not report a separate API generated-code freshness test gap only because CI does not run `make api-generate` plus a generated-file diff check.
 
 ## CI
 

--- a/area/apps/main.go
+++ b/area/apps/main.go
@@ -6,8 +6,12 @@ import (
 )
 
 func main() {
-	pulumi.Run(func(ctx *pulumi.Context) error {
-		config, err := app.ReadConfiguration("apps.hjson")
+	pulumi.Run(run("apps.hjson"))
+}
+
+func run(path string) pulumi.RunFunc {
+	return func(ctx *pulumi.Context) error {
+		config, err := app.ReadConfiguration(path)
 		if err != nil {
 			return err
 		}
@@ -19,5 +23,5 @@ func main() {
 		}
 
 		return nil
-	})
+	}
 }

--- a/area/apps/main_test.go
+++ b/area/apps/main_test.go
@@ -1,35 +1,45 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/alexfalkowski/infraops/v2/internal/app"
 	"github.com/alexfalkowski/infraops/v2/internal/test"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCreate(t *testing.T) {
 	for _, fixture := range fixtures() {
 		t.Run(fixture.name, func(t *testing.T) {
-			config, err := app.ReadConfiguration(fixture.path)
-			require.NoError(t, err)
+			stub := &test.ResourceStub{}
+			stub.FailAllResources()
 
-			applications := config.GetApplications()
-			run := func(ctx *pulumi.Context) error {
-				for _, application := range applications {
-					if err := app.CreateApplication(ctx, app.ConvertApplication(application)); err != nil {
-						return err
-					}
-				}
-
-				return nil
-			}
-
-			require.NoError(t, runWithMocks(run, &test.Stub{}))
-			require.Error(t, runWithMocks(run, &test.ErrStub{}))
+			require.NoError(t, test.RunWithMocks(run(fixture.path), &test.Stub{}))
+			require.Error(t, test.RunWithMocks(run(fixture.path), stub))
 		})
+	}
+}
+
+func TestLeanMakefileCoversConfiguredApps(t *testing.T) {
+	config, err := app.ReadConfiguration("apps.hjson")
+	require.NoError(t, err)
+
+	content, err := os.ReadFile("lean.mk")
+	require.NoError(t, err)
+
+	targets := makefileTargets(string(content))
+	for _, workflow := range []string{"rollout", "verify", "load"} {
+		aggregate := workflow + "-lean"
+		require.Contains(t, targets, aggregate)
+
+		for _, application := range config.GetApplications() {
+			target := workflow + "-" + application.GetName()
+			require.Contains(t, targets[aggregate], target)
+			require.Contains(t, targets, target)
+		}
 	}
 }
 
@@ -45,6 +55,21 @@ func fixtures() []fixture {
 	}
 }
 
-func runWithMocks(run pulumi.RunFunc, mocks pulumi.MockResourceMonitor) error {
-	return pulumi.RunErr(run, pulumi.WithMocks("project", "stack", mocks))
+func makefileTargets(content string) map[string][]string {
+	targets := map[string][]string{}
+	for line := range strings.SplitSeq(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "@") {
+			continue
+		}
+
+		target, dependencies, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+
+		targets[strings.TrimSpace(target)] = strings.Fields(dependencies)
+	}
+
+	return targets
 }

--- a/area/cf/main.go
+++ b/area/cf/main.go
@@ -6,8 +6,12 @@ import (
 )
 
 func main() {
-	pulumi.Run(func(ctx *pulumi.Context) error {
-		config, err := cf.ReadConfiguration("cf.hjson")
+	pulumi.Run(run("cf.hjson"))
+}
+
+func run(path string) pulumi.RunFunc {
+	return func(ctx *pulumi.Context) error {
+		config, err := cf.ReadConfiguration(path)
 		if err != nil {
 			return err
 		}
@@ -31,5 +35,5 @@ func main() {
 		}
 
 		return nil
-	})
+	}
 }

--- a/area/cf/main_test.go
+++ b/area/cf/main_test.go
@@ -4,81 +4,18 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/alexfalkowski/infraops/v2/internal/cf"
 	"github.com/alexfalkowski/infraops/v2/internal/test"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/require"
 )
 
-func TestBalancerZones(t *testing.T) {
+func TestCreate(t *testing.T) {
 	for _, fixture := range fixtures() {
 		t.Run(fixture.name, func(t *testing.T) {
-			config, err := cf.ReadConfiguration(fixture.path)
-			require.NoError(t, err)
+			stub := &test.ResourceStub{}
+			stub.FailAllResources()
 
-			zones := config.GetBalancerZones()
-			run := func(ctx *pulumi.Context) error {
-				for _, zone := range zones {
-					if err := cf.CreateBalancerZone(ctx, cf.ConvertBalancerZone(zone)); err != nil {
-						return err
-					}
-				}
-
-				return nil
-			}
-
-			require.NoError(t, runWithMocks(run, &test.Stub{}))
-			require.Error(t, runWithMocks(run, &test.ErrStub{}))
-		})
-	}
-}
-
-func TestPageZones(t *testing.T) {
-	for _, fixture := range fixtures() {
-		t.Run(fixture.name, func(t *testing.T) {
-			config, err := cf.ReadConfiguration(fixture.path)
-			require.NoError(t, err)
-
-			zones := config.GetPageZones()
-			run := func(ctx *pulumi.Context) error {
-				for _, zone := range zones {
-					if err := cf.CreatePageZone(ctx, cf.ConvertPageZone(zone)); err != nil {
-						return err
-					}
-				}
-
-				return nil
-			}
-
-			require.NoError(t, runWithMocks(run, &test.Stub{}))
-			require.Error(t, runWithMocks(run, &test.ErrStub{}))
-		})
-	}
-}
-
-func TestBuckets(t *testing.T) {
-	for _, fixture := range fixtures() {
-		t.Run(fixture.name, func(t *testing.T) {
-			config, err := cf.ReadConfiguration(fixture.path)
-			require.NoError(t, err)
-
-			buckets := config.GetBuckets()
-			run := func(ctx *pulumi.Context) error {
-				for _, bucket := range buckets {
-					if err := cf.CreateBucket(ctx, cf.ConvertBucket(bucket)); err != nil {
-						return err
-					}
-				}
-
-				return nil
-			}
-
-			require.NoError(t, runWithMocks(run, &test.Stub{}))
-			if len(buckets) == 0 {
-				return
-			}
-
-			require.Error(t, runWithMocks(run, &test.ErrStub{}))
+			require.NoError(t, test.RunWithMocks(run(fixture.path), &test.Stub{}))
+			require.Error(t, test.RunWithMocks(run(fixture.path), stub))
 		})
 	}
 }
@@ -93,8 +30,4 @@ func fixtures() []fixture {
 		{name: "area", path: "cf.hjson"},
 		{name: "shared", path: filepath.Join("..", "..", "internal", "test", "cf.hjson")},
 	}
-}
-
-func runWithMocks(run pulumi.RunFunc, mocks pulumi.MockResourceMonitor) error {
-	return pulumi.RunErr(run, pulumi.WithMocks("project", "stack", mocks))
 }

--- a/area/do/main.go
+++ b/area/do/main.go
@@ -6,8 +6,12 @@ import (
 )
 
 func main() {
-	pulumi.Run(func(ctx *pulumi.Context) error {
-		config, err := do.ReadConfiguration("do.hjson")
+	pulumi.Run(run("do.hjson"))
+}
+
+func run(path string) pulumi.RunFunc {
+	return func(ctx *pulumi.Context) error {
+		config, err := do.ReadConfiguration(path)
 		if err != nil {
 			return err
 		}
@@ -19,5 +23,5 @@ func main() {
 		}
 
 		return nil
-	})
+	}
 }

--- a/area/do/main_test.go
+++ b/area/do/main_test.go
@@ -4,31 +4,18 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/alexfalkowski/infraops/v2/internal/do"
 	"github.com/alexfalkowski/infraops/v2/internal/test"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCreateCluster(t *testing.T) {
 	for _, fixture := range fixtures() {
 		t.Run(fixture.name, func(t *testing.T) {
-			config, err := do.ReadConfiguration(fixture.path)
-			require.NoError(t, err)
+			stub := &test.ResourceStub{}
+			stub.FailAllResources()
 
-			clusters := config.GetClusters()
-			run := func(ctx *pulumi.Context) error {
-				for _, cluster := range clusters {
-					if err := do.CreateCluster(ctx, do.ConvertCluster(cluster)); err != nil {
-						return err
-					}
-				}
-
-				return nil
-			}
-
-			require.NoError(t, runWithMocks(run, &test.Stub{}))
-			require.Error(t, runWithMocks(run, &test.ErrStub{}))
+			require.NoError(t, test.RunWithMocks(run(fixture.path), &test.Stub{}))
+			require.Error(t, test.RunWithMocks(run(fixture.path), stub))
 		})
 	}
 }
@@ -43,8 +30,4 @@ func fixtures() []fixture {
 		{name: "area", path: "do.hjson"},
 		{name: "shared", path: filepath.Join("..", "..", "internal", "test", "do.hjson")},
 	}
-}
-
-func runWithMocks(run pulumi.RunFunc, mocks pulumi.MockResourceMonitor) error {
-	return pulumi.RunErr(run, pulumi.WithMocks("project", "stack", mocks))
 }

--- a/area/gh/main.go
+++ b/area/gh/main.go
@@ -6,8 +6,12 @@ import (
 )
 
 func main() {
-	pulumi.Run(func(ctx *pulumi.Context) error {
-		config, err := gh.ReadConfiguration("gh.hjson")
+	pulumi.Run(run("gh.hjson"))
+}
+
+func run(path string) pulumi.RunFunc {
+	return func(ctx *pulumi.Context) error {
+		config, err := gh.ReadConfiguration(path)
 		if err != nil {
 			return err
 		}
@@ -19,5 +23,5 @@ func main() {
 		}
 
 		return nil
-	})
+	}
 }

--- a/area/gh/main_test.go
+++ b/area/gh/main_test.go
@@ -4,31 +4,18 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/alexfalkowski/infraops/v2/internal/gh"
 	"github.com/alexfalkowski/infraops/v2/internal/test"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCreateRepository(t *testing.T) {
 	for _, fixture := range fixtures() {
 		t.Run(fixture.name, func(t *testing.T) {
-			config, err := gh.ReadConfiguration(fixture.path)
-			require.NoError(t, err)
+			stub := &test.ResourceStub{}
+			stub.FailAllResources()
 
-			repositories := config.GetRepositories()
-			run := func(ctx *pulumi.Context) error {
-				for _, repository := range repositories {
-					if err := gh.CreateRepository(ctx, gh.ConvertRepository(repository)); err != nil {
-						return err
-					}
-				}
-
-				return nil
-			}
-
-			require.NoError(t, runWithMocks(run, &test.Stub{}))
-			require.Error(t, runWithMocks(run, &test.ErrStub{}))
+			require.NoError(t, test.RunWithMocks(run(fixture.path), &test.Stub{}))
+			require.Error(t, test.RunWithMocks(run(fixture.path), stub))
 		})
 	}
 }
@@ -43,8 +30,4 @@ func fixtures() []fixture {
 		{name: "area", path: "gh.hjson"},
 		{name: "shared", path: filepath.Join("..", "..", "internal", "test", "gh.hjson")},
 	}
-}
-
-func runWithMocks(run pulumi.RunFunc, mocks pulumi.MockResourceMonitor) error {
-	return pulumi.RunErr(run, pulumi.WithMocks("project", "stack", mocks))
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -3,11 +3,22 @@ package app_test
 import (
 	"testing"
 
+	v2 "github.com/alexfalkowski/infraops/v2/api/infraops/v2"
 	"github.com/alexfalkowski/infraops/v2/internal/app"
 	"github.com/alexfalkowski/infraops/v2/internal/test"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	configMapResourceType      = "kubernetes:core/v1:ConfigMap"
+	deploymentResourceType     = "kubernetes:apps/v1:Deployment"
+	ingressResourceType        = "kubernetes:networking.k8s.io/v1:Ingress"
+	networkPolicyResourceType  = "kubernetes:networking.k8s.io/v1:NetworkPolicy"
+	pdbResourceType            = "kubernetes:policy/v1:PodDisruptionBudget"
+	serviceAccountResourceType = "kubernetes:core/v1:ServiceAccount"
+	serviceResourceType        = "kubernetes:core/v1:Service"
 )
 
 func TestApp(t *testing.T) {
@@ -21,24 +32,27 @@ func TestApp(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			stub := &resourceStub{}
+			stub := &test.ResourceStub{}
 			run := func(ctx *pulumi.Context) error {
 				return app.CreateApplication(ctx, tt.app)
 			}
 
 			require.NoError(t, pulumi.RunErr(run, pulumi.WithMocks("project", "stack", stub)))
-			require.Equal(t, portNumbers(app.Ports(tt.app)), networkPolicyIngressPorts(stub.networkPolicy))
-			require.Equal(t, portProtocols(app.Ports(tt.app)), servicePortAppProtocols(stub.service))
+			require.Equal(t, portNumbers(app.Ports(tt.app)), networkPolicyIngressPorts(t, resourceOf(t, stub, networkPolicyResourceType)))
+			require.Equal(t, portProtocols(app.Ports(tt.app)), servicePortAppProtocols(t, resourceOf(t, stub, serviceResourceType)))
 		})
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name+" error", func(t *testing.T) {
+			stub := &test.ResourceStub{}
+			stub.FailResource(serviceAccountResourceType)
+
 			run := func(ctx *pulumi.Context) error {
 				return app.CreateApplication(ctx, tt.app)
 			}
 
-			require.Error(t, pulumi.RunErr(run, pulumi.WithMocks("project", "stack", &test.ErrStub{})))
+			require.Error(t, pulumi.RunErr(run, pulumi.WithMocks("project", "stack", stub)))
 		})
 	}
 
@@ -46,22 +60,107 @@ func TestApp(t *testing.T) {
 	require.Error(t, err)
 }
 
-type resourceStub struct {
-	test.Stub
+func TestApplicationReturnsResourceErrors(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		resourceType string
+	}{
+		{name: "service account", resourceType: serviceAccountResourceType},
+		{name: "network policy", resourceType: networkPolicyResourceType},
+		{name: "config map", resourceType: configMapResourceType},
+		{name: "pod disruption budget", resourceType: pdbResourceType},
+		{name: "deployment", resourceType: deploymentResourceType},
+		{name: "service", resourceType: serviceResourceType},
+		{name: "ingress", resourceType: ingressResourceType},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			stub := &test.ResourceStub{}
+			stub.FailResource(tt.resourceType)
 
-	networkPolicy resource.PropertyMap
-	service       resource.PropertyMap
+			run := func(ctx *pulumi.Context) error {
+				return app.CreateApplication(ctx, withResource())
+			}
+
+			require.Error(t, pulumi.RunErr(run, pulumi.WithMocks("project", "stack", stub)))
+			require.NotEmpty(t, stub.Resources(tt.resourceType))
+		})
+	}
 }
 
-func (s *resourceStub) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
-	if args.TypeToken == "kubernetes:networking.k8s.io/v1:NetworkPolicy" {
-		s.networkPolicy = args.Inputs
-	}
-	if args.TypeToken == "kubernetes:core/v1:Service" {
-		s.service = args.Inputs
+func TestApplicationReturnsMissingConfigError(t *testing.T) {
+	stub := &test.ResourceStub{}
+	application := withResource()
+	application.Namespace = "missing-config-fixture"
+
+	run := func(ctx *pulumi.Context) error {
+		return app.CreateApplication(ctx, application)
 	}
 
-	return s.Stub.NewResource(args)
+	require.Error(t, pulumi.RunErr(run, pulumi.WithMocks("project", "stack", stub)))
+	require.Len(t, stub.Resources(serviceAccountResourceType), 1)
+	require.Len(t, stub.Resources(networkPolicyResourceType), 1)
+	require.Empty(t, stub.Resources(configMapResourceType))
+}
+
+func TestConvertedApplicationDeploymentInputs(t *testing.T) {
+	stub := &test.ResourceStub{}
+	application := app.ConvertApplication(&v2.Application{
+		Id:        "1234",
+		Kind:      "internal",
+		Name:      "test",
+		Namespace: "test",
+		Domain:    "test.com",
+		Version:   "1.0.0",
+		Resource:  "unknown",
+		Secrets:   []string{"database"},
+		EnvVars: []*v2.EnvVar{
+			{Name: "LOG_LEVEL", Value: "info"},
+			{Name: "DATABASE_PASSWORD", Value: "secret:database/password"},
+		},
+	})
+	run := func(ctx *pulumi.Context) error {
+		return app.CreateApplication(ctx, application)
+	}
+
+	require.NoError(t, pulumi.RunErr(run, pulumi.WithMocks("project", "stack", stub)))
+	deployment := resourceOf(t, stub, deploymentResourceType)
+	require.Equal(t, "125m", resourceRequest(deployment, "cpu"))
+	require.Equal(t, "250m", resourceLimit(deployment, "cpu"))
+	require.Equal(t, "64Mi", resourceRequest(deployment, "memory"))
+	require.Equal(t, "128Mi", resourceLimit(deployment, "memory"))
+	require.Equal(t, "1Gi", resourceRequest(deployment, "ephemeral-storage"))
+	require.Equal(t, "2Gi", resourceLimit(deployment, "ephemeral-storage"))
+
+	secret := envVar(deployment, "DATABASE_PASSWORD")
+	secretKeyRef := test.Property(t, test.Property(t, secret, "valueFrom").ObjectValue(), "secretKeyRef").ObjectValue()
+	require.Equal(t, "database-secret", test.Property(t, secretKeyRef, "name").StringValue())
+	require.Equal(t, "password", test.Property(t, secretKeyRef, "key").StringValue())
+}
+
+func TestExternalApplicationOmitsInternalResources(t *testing.T) {
+	stub := &test.ResourceStub{}
+	application := app.ConvertApplication(&v2.Application{
+		Id:        "1234",
+		Kind:      "external",
+		Name:      "test",
+		Namespace: "test",
+		Domain:    "test.com",
+		Version:   "1.0.0",
+		Resource:  "small",
+	})
+	run := func(ctx *pulumi.Context) error {
+		return app.CreateApplication(ctx, application)
+	}
+
+	require.NoError(t, pulumi.RunErr(run, pulumi.WithMocks("project", "stack", stub)))
+	deployment := resourceOf(t, stub, deploymentResourceType)
+	componentLabel := resource.PropertyKey("circleci.com/component-name")
+	require.Empty(t, stub.Resources(configMapResourceType))
+	require.Empty(t, test.Property(t, metadata(deployment), "annotations").ObjectValue())
+	require.NotContains(t, test.Property(t, metadata(deployment), "labels").ObjectValue(), componentLabel)
+	require.NotContains(t, test.Property(t, podTemplateMetadata(deployment), "labels").ObjectValue(), componentLabel)
+	require.NotContains(t, podSpec(deployment), resource.PropertyKey("volumes"))
+	require.NotContains(t, container(deployment), resource.PropertyKey("volumeMounts"))
 }
 
 func withResource() *app.App {
@@ -116,10 +215,21 @@ func portProtocols(ports []app.Port) []string {
 	return protocols
 }
 
-func networkPolicyIngressPorts(policy resource.PropertyMap) []int {
-	spec := policy[resource.PropertyKey("spec")].ObjectValue()
-	ingress := spec[resource.PropertyKey("ingress")].ArrayValue()
-	ports := ingress[0].ObjectValue()[resource.PropertyKey("ports")].ArrayValue()
+func resourceOf(t *testing.T, stub *test.ResourceStub, token string) resource.PropertyMap {
+	t.Helper()
+
+	resources := stub.Resources(token)
+	require.Len(t, resources, 1)
+
+	return resources[0]
+}
+
+func networkPolicyIngressPorts(t *testing.T, policy resource.PropertyMap) []int {
+	t.Helper()
+
+	spec := test.Property(t, policy, "spec").ObjectValue()
+	ingress := test.Property(t, spec, "ingress").ArrayValue()
+	ports := test.Property(t, ingress[0].ObjectValue(), "ports").ArrayValue()
 
 	values := make([]int, 0, len(ports))
 	for _, port := range ports {
@@ -130,9 +240,59 @@ func networkPolicyIngressPorts(policy resource.PropertyMap) []int {
 	return values
 }
 
-func servicePortAppProtocols(service resource.PropertyMap) []string {
-	spec := service[resource.PropertyKey("spec")].ObjectValue()
-	ports := spec[resource.PropertyKey("ports")].ArrayValue()
+func metadata(deployment resource.PropertyMap) resource.PropertyMap {
+	return deployment[resource.PropertyKey("metadata")].ObjectValue()
+}
+
+func podTemplateMetadata(deployment resource.PropertyMap) resource.PropertyMap {
+	return deploymentSpec(deployment)[resource.PropertyKey("template")].ObjectValue()[resource.PropertyKey("metadata")].ObjectValue()
+}
+
+func podSpec(deployment resource.PropertyMap) resource.PropertyMap {
+	template := deploymentSpec(deployment)[resource.PropertyKey("template")].ObjectValue()
+	return template[resource.PropertyKey("spec")].ObjectValue()
+}
+
+func container(deployment resource.PropertyMap) resource.PropertyMap {
+	containers := podSpec(deployment)[resource.PropertyKey("containers")].ArrayValue()
+	return containers[0].ObjectValue()
+}
+
+func envVar(deployment resource.PropertyMap, name string) resource.PropertyMap {
+	envs := container(deployment)[resource.PropertyKey("env")].ArrayValue()
+	for _, env := range envs {
+		value := env.ObjectValue()
+		if value[resource.PropertyKey("name")].StringValue() == name {
+			return value
+		}
+	}
+
+	return nil
+}
+
+func resourceRequest(deployment resource.PropertyMap, name string) string {
+	return resourceValue(deployment, "requests", name)
+}
+
+func resourceLimit(deployment resource.PropertyMap, name string) string {
+	return resourceValue(deployment, "limits", name)
+}
+
+func resourceValue(deployment resource.PropertyMap, kind, name string) string {
+	resources := container(deployment)[resource.PropertyKey("resources")].ObjectValue()
+	values := resources[resource.PropertyKey(kind)].ObjectValue()
+	return values[resource.PropertyKey(name)].StringValue()
+}
+
+func deploymentSpec(deployment resource.PropertyMap) resource.PropertyMap {
+	return deployment[resource.PropertyKey("spec")].ObjectValue()
+}
+
+func servicePortAppProtocols(t *testing.T, service resource.PropertyMap) []string {
+	t.Helper()
+
+	spec := test.Property(t, service, "spec").ObjectValue()
+	ports := test.Property(t, spec, "ports").ArrayValue()
 
 	values := make([]string, 0, len(ports))
 	for _, port := range ports {

--- a/internal/app/version/version_test.go
+++ b/internal/app/version/version_test.go
@@ -1,15 +1,29 @@
 package version_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/alexfalkowski/infraops/v2/internal/app"
 	"github.com/alexfalkowski/infraops/v2/internal/app/version"
 	"github.com/stretchr/testify/require"
 )
 
 func TestValidUpdate(t *testing.T) {
-	err := version.Update("app1", "1.1.0", "../test/apps.hjson")
+	path := copyFixture(t)
+
+	require.NoError(t, version.Update("app1", "2.0.0", path))
+
+	config, err := app.ReadConfiguration(path)
 	require.NoError(t, err)
+
+	applications := config.GetApplications()
+	require.Len(t, applications, 2)
+	require.Equal(t, "app1", applications[0].GetName())
+	require.Equal(t, "2.0.0", applications[0].GetVersion())
+	require.Equal(t, "app2", applications[1].GetName())
+	require.Equal(t, "1.0.0", applications[1].GetVersion())
 }
 
 func TestInvalidUpdate(t *testing.T) {
@@ -19,5 +33,23 @@ func TestInvalidUpdate(t *testing.T) {
 
 func TestMissingUpdate(t *testing.T) {
 	err := version.Update("none", "1.1.0", "../test/apps.hjson")
-	require.Error(t, err)
+	require.ErrorIs(t, err, version.ErrNotFound)
+}
+
+func copyFixture(t *testing.T) string {
+	t.Helper()
+
+	data, err := os.ReadFile("../test/apps.hjson")
+	require.NoError(t, err)
+
+	file, err := os.CreateTemp(t.TempDir(), "apps-*.hjson")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, file.Close())
+	}()
+
+	_, err = file.Write(data)
+	require.NoError(t, err)
+
+	return filepath.Clean(file.Name())
 }

--- a/internal/cf/cf_test.go
+++ b/internal/cf/cf_test.go
@@ -5,75 +5,79 @@ import (
 
 	"github.com/alexfalkowski/infraops/v2/internal/cf"
 	"github.com/alexfalkowski/infraops/v2/internal/test"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	r2BucketResourceType       = "cloudflare:index/r2Bucket:R2Bucket"
+	r2CustomDomainResourceType = "cloudflare:index/r2CustomDomain:R2CustomDomain"
+	recordResourceType         = "cloudflare:index/record:Record"
+	zoneSettingResourceType    = "cloudflare:index/zoneSetting:ZoneSetting"
+)
+
 func TestCreateBalancerZone(t *testing.T) {
-	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
-		z := &cf.BalancerZone{
-			Name:        "test",
-			Domain:      "test.com",
-			RecordNames: []string{"test"},
-			IPV4:        "127.0.0.1",
-			IPV6:        "::1",
-		}
+	stub := &test.ResourceStub{}
+	require.NoError(t, createBalancerZone(t, stub))
+	requireRecord(t, stub.Resources(recordResourceType), "A", "test.test.com", "127.0.0.1")
+	requireRecord(t, stub.Resources(recordResourceType), "AAAA", "test.test.com", "::1")
+	requireZoneSetting(t, stub.Resources(zoneSettingResourceType), "ssl", "full")
 
-		err := cf.CreateBalancerZone(ctx, z)
-		require.NoError(t, err)
+	stub = &test.ResourceStub{}
+	stub.FailResource(zoneSettingResourceType)
+	require.Error(t, createBalancerZone(t, stub))
+}
 
-		return nil
-	}, pulumi.WithMocks("project", "stack", &test.Stub{}))
-	require.NoError(t, err)
+func TestCreateBalancerZoneReturnsResourceErrors(t *testing.T) {
+	t.Run("setting", func(t *testing.T) {
+		stub := &test.ResourceStub{}
+		stub.FailResource(zoneSettingResourceType)
 
-	err = pulumi.RunErr(func(ctx *pulumi.Context) error {
-		z := &cf.BalancerZone{
-			Name:        "test",
-			Domain:      "test.com",
-			RecordNames: []string{"test"},
-			IPV4:        "127.0.0.1",
-			IPV6:        "::1",
-		}
+		require.Error(t, createBalancerZone(t, stub))
+		require.NotEmpty(t, stub.Resources(zoneSettingResourceType))
+	})
 
-		err := cf.CreateBalancerZone(ctx, z)
-		require.NoError(t, err)
+	t.Run("a record", func(t *testing.T) {
+		stub := &test.ResourceStub{}
+		stub.FailResourceAt(recordResourceType, 1)
 
-		return nil
-	}, pulumi.WithMocks("project", "stack", &test.ErrStub{}))
-	require.Error(t, err)
+		require.Error(t, createBalancerZone(t, stub))
+		require.NotEmpty(t, stub.Resources(recordResourceType))
+	})
+
+	t.Run("aaaa record", func(t *testing.T) {
+		stub := &test.ResourceStub{}
+		stub.FailResourceAt(recordResourceType, 2)
+
+		require.Error(t, createBalancerZone(t, stub))
+		requireRecord(t, stub.Resources(recordResourceType), "A", "test.test.com", "127.0.0.1")
+		require.Len(t, stub.Resources(recordResourceType), 2)
+	})
 }
 
 func TestCreatePagerZone(t *testing.T) {
-	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
-		z := &cf.PageZone{
-			Name:   "test",
-			Domain: "test.com",
-			Host:   "test.github.io",
-		}
+	stub := &test.ResourceStub{}
+	require.NoError(t, createPageZone(t, stub))
+	requireRecord(t, stub.Resources(recordResourceType), "CNAME", "www.test.com", "test.github.io")
+	requireZoneSetting(t, stub.Resources(zoneSettingResourceType), "ssl", "strict")
 
-		err := cf.CreatePageZone(ctx, z)
-		require.NoError(t, err)
+	stub = &test.ResourceStub{}
+	stub.FailResource(zoneSettingResourceType)
+	require.Error(t, createPageZone(t, stub))
+}
 
-		return nil
-	}, pulumi.WithMocks("project", "stack", &test.Stub{}))
-	require.NoError(t, err)
+func TestCreatePagerZoneReturnsRecordError(t *testing.T) {
+	stub := &test.ResourceStub{}
+	stub.FailResource(recordResourceType)
 
-	err = pulumi.RunErr(func(ctx *pulumi.Context) error {
-		z := &cf.PageZone{
-			Name:   "test",
-			Domain: "test.com",
-			Host:   "test.github.io",
-		}
-
-		err := cf.CreatePageZone(ctx, z)
-		require.NoError(t, err)
-
-		return nil
-	}, pulumi.WithMocks("project", "stack", &test.ErrStub{}))
-	require.Error(t, err)
+	require.Error(t, createPageZone(t, stub))
+	requireZoneSetting(t, stub.Resources(zoneSettingResourceType), "ssl", "strict")
+	require.Len(t, stub.Resources(recordResourceType), 1)
 }
 
 func TestCreateBucket(t *testing.T) {
+	stub := &test.ResourceStub{}
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
 		bucket := &cf.Bucket{
 			Name:   "test",
@@ -88,9 +92,12 @@ func TestCreateBucket(t *testing.T) {
 		require.NoError(t, err)
 
 		return nil
-	}, pulumi.WithMocks("project", "stack", &test.Stub{}))
+	}, pulumi.WithMocks("project", "stack", stub))
 	require.NoError(t, err)
+	requireBucket(t, stub.Resources(r2BucketResourceType), "test", "eeur")
+	requireCustomDomain(t, stub.Resources(r2CustomDomainResourceType), "test", "www.test.com", "test")
 
+	stub = &test.ResourceStub{}
 	err = pulumi.RunErr(func(ctx *pulumi.Context) error {
 		bucket := &cf.Bucket{
 			Name:   "test",
@@ -101,6 +108,131 @@ func TestCreateBucket(t *testing.T) {
 		require.NoError(t, err)
 
 		return nil
-	}, pulumi.WithMocks("project", "stack", &test.ErrStub{}))
+	}, pulumi.WithMocks("project", "stack", stub))
+	require.NoError(t, err)
+	requireBucket(t, stub.Resources(r2BucketResourceType), "test", "eeur")
+	require.Empty(t, stub.Resources(r2CustomDomainResourceType))
+
+	stub = &test.ResourceStub{}
+	stub.FailResource(r2BucketResourceType)
+	err = pulumi.RunErr(func(ctx *pulumi.Context) error {
+		bucket := &cf.Bucket{
+			Name:   "test",
+			Region: "eeur",
+		}
+
+		return cf.CreateBucket(ctx, bucket)
+	}, pulumi.WithMocks("project", "stack", stub))
 	require.Error(t, err)
+	require.Len(t, stub.Resources(r2BucketResourceType), 1)
+}
+
+func TestCreateBucketReturnsCustomDomainError(t *testing.T) {
+	stub := &test.ResourceStub{}
+	stub.FailResource(r2CustomDomainResourceType)
+
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		bucket := &cf.Bucket{
+			Name:   "test",
+			Region: "eeur",
+			Zone: &cf.BucketZone{
+				ID:     "test",
+				Domain: "www.test.com",
+			},
+		}
+
+		return cf.CreateBucket(ctx, bucket)
+	}, pulumi.WithMocks("project", "stack", stub))
+	require.Error(t, err)
+	requireBucket(t, stub.Resources(r2BucketResourceType), "test", "eeur")
+	require.Len(t, stub.Resources(r2CustomDomainResourceType), 1)
+}
+
+func createBalancerZone(t *testing.T, mocks pulumi.MockResourceMonitor) error {
+	t.Helper()
+
+	return test.RunWithMocks(func(ctx *pulumi.Context) error {
+		z := &cf.BalancerZone{
+			Name:        "test",
+			Domain:      "test.com",
+			RecordNames: []string{"test"},
+			IPV4:        "127.0.0.1",
+			IPV6:        "::1",
+		}
+
+		return cf.CreateBalancerZone(ctx, z)
+	}, mocks)
+}
+
+func createPageZone(t *testing.T, mocks pulumi.MockResourceMonitor) error {
+	t.Helper()
+
+	return test.RunWithMocks(func(ctx *pulumi.Context) error {
+		z := &cf.PageZone{
+			Name:   "test",
+			Domain: "test.com",
+			Host:   "test.github.io",
+		}
+
+		return cf.CreatePageZone(ctx, z)
+	}, mocks)
+}
+
+func requireRecord(t *testing.T, records []resource.PropertyMap, kind, name, content string) {
+	t.Helper()
+
+	for _, record := range records {
+		if test.Property(t, record, "type").StringValue() != kind {
+			continue
+		}
+		if test.Property(t, record, "name").StringValue() != name {
+			continue
+		}
+
+		require.Equal(t, content, test.Property(t, record, "content").StringValue())
+		require.True(t, test.Property(t, record, "proxied").BoolValue())
+		require.Equal(t, 1, int(test.Property(t, record, "ttl").NumberValue()))
+		return
+	}
+
+	require.Failf(t, "missing DNS record", "%s %s", kind, name)
+}
+
+func requireBucket(t *testing.T, buckets []resource.PropertyMap, name, region string) {
+	t.Helper()
+
+	require.Len(t, buckets, 1)
+
+	bucket := buckets[0]
+	require.Equal(t, name, test.Property(t, bucket, "name").StringValue())
+	require.Equal(t, region, test.Property(t, bucket, "location").StringValue())
+	require.Equal(t, "Standard", test.Property(t, bucket, "storageClass").StringValue())
+}
+
+func requireCustomDomain(t *testing.T, domains []resource.PropertyMap, bucket, domain, zone string) {
+	t.Helper()
+
+	require.Len(t, domains, 1)
+
+	customDomain := domains[0]
+	require.Equal(t, bucket, test.Property(t, customDomain, "bucketName").StringValue())
+	require.Equal(t, domain, test.Property(t, customDomain, "domain").StringValue())
+	require.True(t, test.Property(t, customDomain, "enabled").BoolValue())
+	require.Equal(t, zone, test.Property(t, customDomain, "zoneId").StringValue())
+	require.Equal(t, "1.2", test.Property(t, customDomain, "minTls").StringValue())
+}
+
+func requireZoneSetting(t *testing.T, settings []resource.PropertyMap, name, value string) {
+	t.Helper()
+
+	for _, setting := range settings {
+		if test.Property(t, setting, "settingId").StringValue() != name {
+			continue
+		}
+
+		require.Equal(t, value, test.Property(t, setting, "value").StringValue())
+		return
+	}
+
+	require.Failf(t, "missing zone setting", "%s", name)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,16 @@
+package config_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	v2 "github.com/alexfalkowski/infraops/v2/api/infraops/v2"
+	"github.com/alexfalkowski/infraops/v2/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteReturnsStatError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.hjson")
+
+	require.Error(t, config.Write(path, &v2.Kubernetes{}))
+}

--- a/internal/do/do_test.go
+++ b/internal/do/do_test.go
@@ -3,26 +3,76 @@ package do_test
 import (
 	"testing"
 
+	v2 "github.com/alexfalkowski/infraops/v2/api/infraops/v2"
 	"github.com/alexfalkowski/infraops/v2/internal/do"
 	"github.com/alexfalkowski/infraops/v2/internal/test"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	kubernetesClusterResourceType = "digitalocean:index/kubernetesCluster:KubernetesCluster"
+	vpcResourceType               = "digitalocean:index/vpc:Vpc"
+)
+
 func TestCreateCluster(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		resource string
+		size     string
+	}{
+		{name: "small", resource: "small", size: "s-2vcpu-4gb"},
+		{name: "medium", resource: "medium", size: "s-4vcpu-8gb"},
+		{name: "unknown uses small", resource: "unknown", size: "s-2vcpu-4gb"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			stub := &test.ResourceStub{}
+			cluster := do.ConvertCluster(&v2.Cluster{
+				Name:        "test",
+				Description: "test",
+				Resource:    tt.resource,
+			})
+			err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+				require.NoError(t, do.CreateCluster(ctx, cluster))
+
+				return nil
+			}, pulumi.WithMocks("project", "stack", stub))
+			require.NoError(t, err)
+			requireNodePoolSize(t, stub.Resources(kubernetesClusterResourceType), tt.size)
+		})
+	}
+
+	stub := &test.ResourceStub{}
+	stub.FailResource(vpcResourceType)
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
 		p := &do.Cluster{Name: "test", Description: "test"}
 		require.NoError(t, do.CreateCluster(ctx, p))
 
 		return nil
-	}, pulumi.WithMocks("project", "stack", &test.Stub{}))
-	require.NoError(t, err)
-
-	err = pulumi.RunErr(func(ctx *pulumi.Context) error {
-		p := &do.Cluster{Name: "test", Description: "test"}
-		require.NoError(t, do.CreateCluster(ctx, p))
-
-		return nil
-	}, pulumi.WithMocks("project", "stack", &test.ErrStub{}))
+	}, pulumi.WithMocks("project", "stack", stub))
 	require.Error(t, err)
+	require.Len(t, stub.Resources(vpcResourceType), 1)
+}
+
+func TestCreateClusterReturnsKubernetesClusterError(t *testing.T) {
+	stub := &test.ResourceStub{}
+	stub.FailResource(kubernetesClusterResourceType)
+
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+		p := &do.Cluster{Name: "test", Description: "test"}
+		return do.CreateCluster(ctx, p)
+	}, pulumi.WithMocks("project", "stack", stub))
+	require.Error(t, err)
+	require.Len(t, stub.Resources(vpcResourceType), 1)
+	require.Len(t, stub.Resources(kubernetesClusterResourceType), 1)
+}
+
+func requireNodePoolSize(t *testing.T, clusters []resource.PropertyMap, size string) {
+	t.Helper()
+
+	require.Len(t, clusters, 1)
+
+	nodePool := test.Property(t, clusters[0], "nodePool").ObjectValue()
+	require.Equal(t, size, test.Property(t, nodePool, "size").StringValue())
 }

--- a/internal/gh/gh_test.go
+++ b/internal/gh/gh_test.go
@@ -6,64 +6,86 @@ import (
 	v2 "github.com/alexfalkowski/infraops/v2/api/infraops/v2"
 	"github.com/alexfalkowski/infraops/v2/internal/gh"
 	"github.com/alexfalkowski/infraops/v2/internal/test"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	branchProtectionResourceType        = "github:index/branchProtection:BranchProtection"
+	repositoryResourceType              = "github:index/repository:Repository"
+	repositoryCollaboratorResourceType  = "github:index/repositoryCollaborator:RepositoryCollaborator"
+	repositoryPagesResourceType         = "github:index/repositoryPages:RepositoryPages"
+	repositoryVulnerabilityResourceType = "github:index/repositoryVulnerabilityAlerts:RepositoryVulnerabilityAlerts"
+)
+
 func TestCreateRepository(t *testing.T) {
-	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
-		a := &gh.Repository{
-			Name: "test", Description: "test", HomepageURL: "https://alexfalkowski.github.io/test",
-			Template: &gh.Template{Owner: "alexfalkowski", Repository: "go-service-template"},
-			Checks:   gh.Checks{"ci/circleci: build"},
-		}
+	stub := &test.ResourceStub{}
+	require.NoError(t, createRepository(t, fullRepository(), stub))
+	requireBranchProtection(t, stub.Resources(branchProtectionResourceType))
+	requirePages(t, stub.Resources(repositoryPagesResourceType))
+	requireCollaborator(t, stub.Resources(repositoryCollaboratorResourceType))
+}
 
-		err := gh.CreateRepository(ctx, a)
-		require.NoError(t, err)
+func TestCreateRepositoryRequiresChecks(t *testing.T) {
+	repository := &gh.Repository{
+		Name: "test", Description: "test", HomepageURL: "https://alexfalkowski.github.io/test",
+	}
 
-		return nil
-	}, pulumi.WithMocks("project", "stack", &test.Stub{}))
-	require.NoError(t, err)
+	require.Error(t, createRepository(t, repository, &test.Stub{}))
+}
 
-	err = pulumi.RunErr(func(ctx *pulumi.Context) error {
-		a := &gh.Repository{
-			Name: "test", Description: "test", HomepageURL: "https://alexfalkowski.github.io/test",
-		}
+func TestCreateRepositoryRequiresCompleteTemplate(t *testing.T) {
+	repository := &gh.Repository{
+		Name: "test", Description: "test", HomepageURL: "https://alexfalkowski.github.io/test",
+		Template: &gh.Template{Owner: "alexfalkowski"},
+		Checks:   gh.Checks{"ci/circleci: build"},
+	}
 
-		err := gh.CreateRepository(ctx, a)
-		require.Error(t, err)
+	require.Error(t, createRepository(t, repository, &test.Stub{}))
+}
 
-		return nil
-	}, pulumi.WithMocks("project", "stack", &test.Stub{}))
-	require.NoError(t, err)
+func TestCreateRepositoryReturnsRepositoryError(t *testing.T) {
+	stub := &test.ResourceStub{}
+	stub.FailResource(repositoryResourceType)
 
-	err = pulumi.RunErr(func(ctx *pulumi.Context) error {
-		a := &gh.Repository{
-			Name: "test", Description: "test", HomepageURL: "https://alexfalkowski.github.io/test",
-			Template: &gh.Template{Owner: "alexfalkowski"},
-			Checks:   gh.Checks{"ci/circleci: build"},
-		}
+	require.Error(t, createRepository(t, fullRepository(), stub))
+	require.Len(t, stub.Resources(repositoryResourceType), 1)
+}
 
-		err := gh.CreateRepository(ctx, a)
-		require.Error(t, err)
+func TestCreateRepositoryReturnsVulnerabilityAlertsError(t *testing.T) {
+	stub := &test.ResourceStub{}
+	stub.FailResource(repositoryVulnerabilityResourceType)
 
-		return nil
-	}, pulumi.WithMocks("project", "stack", &test.Stub{}))
-	require.NoError(t, err)
+	require.Error(t, createRepository(t, fullRepository(), stub))
+	require.Len(t, stub.Resources(repositoryResourceType), 1)
+	require.Len(t, stub.Resources(repositoryVulnerabilityResourceType), 1)
+}
 
-	err = pulumi.RunErr(func(ctx *pulumi.Context) error {
-		a := &gh.Repository{
-			Name: "test", Description: "test", HomepageURL: "https://alexfalkowski.github.io/test",
-			Template: &gh.Template{Owner: "alexfalkowski", Repository: "go-service-template"},
-			Checks:   gh.Checks{"ci/circleci: build"},
-		}
+func TestCreateRepositoryReturnsPagesError(t *testing.T) {
+	stub := &test.ResourceStub{}
+	stub.FailResource(repositoryPagesResourceType)
 
-		err := gh.CreateRepository(ctx, a)
-		require.NoError(t, err)
+	require.Error(t, createRepository(t, fullRepository(), stub))
+	require.Len(t, stub.Resources(repositoryVulnerabilityResourceType), 1)
+	require.Len(t, stub.Resources(repositoryPagesResourceType), 1)
+}
 
-		return nil
-	}, pulumi.WithMocks("project", "stack", &test.ErrStub{}))
-	require.Error(t, err)
+func TestCreateRepositoryReturnsBranchProtectionError(t *testing.T) {
+	stub := &test.ResourceStub{}
+	stub.FailResource(branchProtectionResourceType)
+
+	require.Error(t, createRepository(t, fullRepository(), stub))
+	require.Len(t, stub.Resources(branchProtectionResourceType), 1)
+}
+
+func TestCreateRepositoryReturnsCollaboratorError(t *testing.T) {
+	stub := &test.ResourceStub{}
+	stub.FailResource(repositoryCollaboratorResourceType)
+
+	require.Error(t, createRepository(t, fullRepository(), stub))
+	require.Len(t, stub.Resources(branchProtectionResourceType), 1)
+	require.Len(t, stub.Resources(repositoryCollaboratorResourceType), 1)
 }
 
 func TestCreateRepositoryFromIncompleteTemplateConfig(t *testing.T) {
@@ -83,4 +105,80 @@ func TestCreateRepositoryFromIncompleteTemplateConfig(t *testing.T) {
 		return nil
 	}, pulumi.WithMocks("project", "stack", &test.Stub{}))
 	require.NoError(t, err)
+}
+
+func fullRepository() *gh.Repository {
+	return gh.ConvertRepository(&v2.Repository{
+		Name:        "test",
+		Description: "test",
+		HomepageUrl: "https://alexfalkowski.github.io/test",
+		Visibility:  string(gh.Public),
+		Collaborators: &v2.Collaborators{
+			Enabled: true,
+		},
+		Template: &v2.Template{
+			Owner:      "alexfalkowski",
+			Repository: "go-service-template",
+		},
+		Pages: &v2.Pages{
+			Enabled: true,
+			Cname:   "test.alexfalkowski.dev",
+		},
+		Checks: []string{"ci/circleci: build"},
+	})
+}
+
+func createRepository(t *testing.T, repository *gh.Repository, mocks pulumi.MockResourceMonitor) error {
+	t.Helper()
+
+	return test.RunWithMocks(func(ctx *pulumi.Context) error {
+		return gh.CreateRepository(ctx, repository)
+	}, mocks)
+}
+
+func requireBranchProtection(t *testing.T, protections []resource.PropertyMap) {
+	t.Helper()
+
+	require.Len(t, protections, 1)
+
+	protection := protections[0]
+	require.Equal(t, "master", test.Property(t, protection, "pattern").StringValue())
+	require.True(t, test.Property(t, protection, "requiredLinearHistory").BoolValue())
+
+	reviews := test.Property(t, protection, "requiredPullRequestReviews").ArrayValue()
+	require.Len(t, reviews, 1)
+	review := reviews[0].ObjectValue()
+	require.True(t, test.Property(t, review, "dismissStaleReviews").BoolValue())
+	require.Equal(t, 0, int(test.Property(t, review, "requiredApprovingReviewCount").NumberValue()))
+
+	statusChecks := test.Property(t, protection, "requiredStatusChecks").ArrayValue()
+	require.Len(t, statusChecks, 1)
+	statusCheck := statusChecks[0].ObjectValue()
+	require.True(t, test.Property(t, statusCheck, "strict").BoolValue())
+	require.Equal(t, []string{"ci/circleci: build"}, test.StringValues(test.Property(t, statusCheck, "contexts").ArrayValue()))
+}
+
+func requirePages(t *testing.T, pages []resource.PropertyMap) {
+	t.Helper()
+
+	require.Len(t, pages, 1)
+
+	page := pages[0]
+	require.Equal(t, "legacy", test.Property(t, page, "buildType").StringValue())
+	require.Equal(t, "test.alexfalkowski.dev", test.Property(t, page, "cname").StringValue())
+	require.Equal(t, "test", test.Property(t, page, "repository").StringValue())
+
+	source := test.Property(t, page, "source").ObjectValue()
+	require.Equal(t, "master", test.Property(t, source, "branch").StringValue())
+}
+
+func requireCollaborator(t *testing.T, collaborators []resource.PropertyMap) {
+	t.Helper()
+
+	require.Len(t, collaborators, 1)
+
+	collaborator := collaborators[0]
+	require.Equal(t, "admin", test.Property(t, collaborator, "permission").StringValue())
+	require.Equal(t, "alexfalkowski/test", test.Property(t, collaborator, "repository").StringValue())
+	require.Equal(t, "lean-thoughts-ci", test.Property(t, collaborator, "username").StringValue())
 }

--- a/internal/test/stub.go
+++ b/internal/test/stub.go
@@ -2,10 +2,17 @@ package test
 
 import (
 	"errors"
+	"sync"
+	"testing"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
+
+// RunWithMocks runs a Pulumi program with the standard project/stack names and mocks.
+func RunWithMocks(run pulumi.RunFunc, mocks pulumi.MockResourceMonitor) error {
+	return pulumi.RunErr(run, pulumi.WithMocks("project", "stack", mocks))
+}
 
 // Stub is a pulumi.Mocks implementation that returns inputs unchanged and never errors.
 type Stub struct{}
@@ -20,21 +27,128 @@ func (*Stub) NewResource(args pulumi.MockResourceArgs) (string, resource.Propert
 	return "", args.Inputs, nil
 }
 
-// ErrStub is a pulumi.Mocks implementation that always returns an error.
-//
-// It is useful for exercising error-handling paths in Pulumi programs.
-type ErrStub struct{}
+// ResourceStub is a pulumi.Mocks implementation that records created resource inputs by type token.
+type ResourceStub struct {
+	Stub
 
-// Call returns an error for every mocked provider call.
-//
-//nolint:err113
-func (*ErrStub) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
-	return args.Args, errors.New("bad call")
+	failures  map[string][]resourceFailure
+	failAll   error
+	resources map[string][]resource.PropertyMap
+	mu        sync.Mutex
 }
 
-// NewResource returns an error for every mocked resource creation.
+type resourceFailure struct {
+	err        error
+	occurrence int
+}
+
+// ErrResource is the default error returned by ResourceStub for targeted resource failures.
+var ErrResource = errors.New("bad resource")
+
+// FailResource makes every resource creation for token fail with ErrResource.
+func (s *ResourceStub) FailResource(token string) {
+	s.FailResourceWith(token, ErrResource)
+}
+
+// FailAllResources makes every resource creation fail with ErrResource.
+func (s *ResourceStub) FailAllResources() {
+	s.FailAllResourcesWith(ErrResource)
+}
+
+// FailAllResourcesWith makes every resource creation fail with err.
+func (s *ResourceStub) FailAllResourcesWith(err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.failAll = err
+}
+
+// FailResourceWith makes every resource creation for token fail with err.
+func (s *ResourceStub) FailResourceWith(token string, err error) {
+	s.failResource(token, 0, err)
+}
+
+// FailResourceAt makes the occurrence-th resource creation for token fail with ErrResource.
 //
-//nolint:err113
-func (*ErrStub) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
-	return "", args.Inputs, errors.New("bad resource")
+// Occurrence is one-based.
+func (s *ResourceStub) FailResourceAt(token string, occurrence int) {
+	s.FailResourceAtWith(token, occurrence, ErrResource)
+}
+
+// FailResourceAtWith makes the occurrence-th resource creation for token fail with err.
+//
+// Occurrence is one-based.
+func (s *ResourceStub) FailResourceAtWith(token string, occurrence int, err error) {
+	s.failResource(token, occurrence, err)
+}
+
+// NewResource records the resource inputs by Pulumi type token and returns the inputs unchanged.
+func (s *ResourceStub) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	s.mu.Lock()
+
+	if s.resources == nil {
+		s.resources = make(map[string][]resource.PropertyMap)
+	}
+	s.resources[args.TypeToken] = append(s.resources[args.TypeToken], args.Inputs)
+	occurrence := len(s.resources[args.TypeToken])
+	err := s.resourceError(args.TypeToken, occurrence)
+	s.mu.Unlock()
+
+	if err != nil {
+		return "", args.Inputs, err
+	}
+
+	return s.Stub.NewResource(args)
+}
+
+// Resources returns the resource inputs recorded for token.
+func (s *ResourceStub) Resources(token string) []resource.PropertyMap {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	resources := s.resources[token]
+	return append([]resource.PropertyMap(nil), resources...)
+}
+
+func (s *ResourceStub) failResource(token string, occurrence int, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.failures == nil {
+		s.failures = make(map[string][]resourceFailure)
+	}
+	s.failures[token] = append(s.failures[token], resourceFailure{err: err, occurrence: occurrence})
+}
+
+func (s *ResourceStub) resourceError(token string, occurrence int) error {
+	if s.failAll != nil {
+		return s.failAll
+	}
+	for _, failure := range s.failures[token] {
+		if failure.occurrence == 0 || failure.occurrence == occurrence {
+			return failure.err
+		}
+	}
+	return nil
+}
+
+// Property returns the property value for key or fails the test.
+func Property(t *testing.T, properties resource.PropertyMap, key string) resource.PropertyValue {
+	t.Helper()
+
+	value, ok := properties[resource.PropertyKey(key)]
+	if !ok {
+		t.Fatalf("missing %s", key)
+	}
+
+	return value
+}
+
+// StringValues converts Pulumi property values to strings.
+func StringValues(values []resource.PropertyValue) []string {
+	strings := make([]string, 0, len(values))
+	for _, value := range values {
+		strings = append(strings, value.StringValue())
+	}
+	return strings
 }

--- a/internal/test/stub_test.go
+++ b/internal/test/stub_test.go
@@ -1,0 +1,54 @@
+package test_test
+
+import (
+	"testing"
+
+	infraopstest "github.com/alexfalkowski/infraops/v2/internal/test"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/stretchr/testify/require"
+)
+
+const resourceType = "test:index/resource:Resource"
+
+func TestResourceStubRecordsResources(t *testing.T) {
+	stub := &infraopstest.ResourceStub{}
+	inputs := resource.PropertyMap{
+		resource.PropertyKey("name"): resource.NewStringProperty("test"),
+	}
+
+	_, outputs, err := stub.NewResource(pulumi.MockResourceArgs{TypeToken: resourceType, Inputs: inputs})
+	require.NoError(t, err)
+	require.Equal(t, inputs, outputs)
+	require.Equal(t, []resource.PropertyMap{inputs}, stub.Resources(resourceType))
+}
+
+func TestResourceStubFailsResource(t *testing.T) {
+	stub := &infraopstest.ResourceStub{}
+	stub.FailResource(resourceType)
+
+	_, _, err := stub.NewResource(pulumi.MockResourceArgs{TypeToken: resourceType, Inputs: resource.PropertyMap{}})
+	require.ErrorIs(t, err, infraopstest.ErrResource)
+	require.Len(t, stub.Resources(resourceType), 1)
+}
+
+func TestResourceStubFailsAllResources(t *testing.T) {
+	stub := &infraopstest.ResourceStub{}
+	stub.FailAllResources()
+
+	_, _, err := stub.NewResource(pulumi.MockResourceArgs{TypeToken: resourceType, Inputs: resource.PropertyMap{}})
+	require.ErrorIs(t, err, infraopstest.ErrResource)
+	require.Len(t, stub.Resources(resourceType), 1)
+}
+
+func TestResourceStubFailsResourceAtOccurrence(t *testing.T) {
+	stub := &infraopstest.ResourceStub{}
+	stub.FailResourceAt(resourceType, 2)
+
+	_, _, err := stub.NewResource(pulumi.MockResourceArgs{TypeToken: resourceType, Inputs: resource.PropertyMap{}})
+	require.NoError(t, err)
+
+	_, _, err = stub.NewResource(pulumi.MockResourceArgs{TypeToken: resourceType, Inputs: resource.PropertyMap{}})
+	require.ErrorIs(t, err, infraopstest.ErrResource)
+	require.Len(t, stub.Resources(resourceType), 2)
+}


### PR DESCRIPTION
## What

- add reusable Pulumi resource recording helpers for package tests.
- cover app, Cloudflare, DigitalOcean, and GitHub Pulumi resource inputs.
- route area tests through configurable Pulumi entrypoints and add CI coverage for build helpers.

## Why

- protect repo-owned infrastructure wiring discovered during the test-gap pass.
- reduce duplicated Pulumi mock plumbing across packages.

## Testing

- `make dep` - passed
- `make build-bump build-format` - passed
- `make lint` - passed
- `make specs` - passed
- `go test -race -mod=vendor ./internal/test ./internal/app ./internal/cf ./internal/gh` - passed
