### PR TITLE
docs(go): clarify infrastructure contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,7 @@ make area=<apps|cf|do|gh> pulumi-preview
 make area=<apps|cf|do|gh> pulumi-update
 make area=<apps|cf|do|gh> pulumi-cancel
 make area=<apps|cf|do|gh> pulumi-delete
+make area=<apps|cf|do|gh> pulumi-refresh
 ```
 
 Local Kubernetes add-ons:
@@ -69,6 +70,9 @@ make -C area/apps verify
 make -C area/apps load
 make -C area/apps lint
 ```
+
+Operator helper targets require the local CLI tools documented in `README.md`: `doctl`,
+`helm`, `kubectl`, `kube-score`, `kubescape`, `curl`, and `vegeta`.
 
 Config tools:
 
@@ -118,6 +122,9 @@ make build-bump
 ## CI
 
 - CircleCI setup config uses path filtering to enable area workflows.
-- The main `build` job runs `make lint`, `make api-lint`, `make api-breaking`, `make sec`, `make specs`, `make coverage`, and Codecov upload.
+- The main `build` job runs `make lint`, `make build-bump`, `make build-format`, `make api-lint`, `make api-breaking`, `make sec`, `make specs`, `make coverage`, and Codecov upload.
 - Area preview jobs run on non-`master`; update jobs run only on `master`.
 - Apps updates also run `make -C area/apps verify`, `load`, and `lint`.
+- Non-`master` workflows run `sync` after build and applicable previews.
+- `master` workflows run the release `version` job after build.
+- `wait-all` depends on build, sync, release, previews, and updates so the workflow has one final aggregate gate.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ Primary tools used:
 - kubectl: <https://kubernetes.io/docs/reference/kubectl/>
 - Helm: <https://helm.sh/>
 - kube-score: <https://kube-score.com/>
+- doctl: <https://docs.digitalocean.com/reference/doctl/>
+- kubescape: <https://kubescape.io/>
+- curl: <https://curl.se/>
+- vegeta: <https://github.com/tsenart/vegeta>
+
+Operator-only helper targets use these tools as needed:
+
+- `make -C area/apps save-config` and `make -C area/k8s save-config`: `doctl`
+- `make -C area/apps lint`: `kube-score`, `kubescape`, `kubectl`
+- `make -C area/apps verify`: `curl`
+- `make -C area/apps load`: `vegeta`
+- `make -C area/k8s setup|delete|pods`: `helm`, `kubectl`
 
 ## Configuration (HJSON + protobuf schema)
 
@@ -94,9 +106,10 @@ env_vars: [
 
 #### `Application.secrets` vs secret env vars (apps)
 
-- `Application.secrets` is an **application-level dependency list** used by the deployment implementation to provision and/or wire Secret resources (for example as volumes or attachments).
+- `Application.secrets` is an **application-level dependency list** used by the deployment implementation to wire existing Kubernetes Secrets as volumes.
 - Secret references in `env_vars` (the `secret:<secretName>/<key>` format) reference **specific keys** in those secrets.
 - They often use the same `<secretName>` values, but they serve different purposes.
+- The app program does not create Secret objects or define Secret keys. For internal apps, each listed secret is expected to exist as `<secretName>-secret` and is mounted at `/etc/secrets/<secretName>`.
 
 #### `Application.resource` sizing (apps)
 
@@ -183,12 +196,26 @@ See:
 
 This file uses the `Kubernetes` message in `api/infraops/v2/service.proto`.
 
+Internal apps also need an application config file at:
+
+- `area/apps/<namespace>/<app>.yaml`
+
+For example, the `bezeichner` app in namespace `lean` reads `area/apps/lean/bezeichner.yaml`.
+The apps Pulumi program turns that file into a Kubernetes ConfigMap entry named `<app>.yaml`,
+then mounts it into the container at `/etc/<app>/<app>.yaml`.
+
 #### Install / Setup
 
-For a full “apply” of what’s in config:
+Prepare the local app namespace/helper resources:
 
 ```bash
 make -C area/apps setup
+```
+
+Apply the Pulumi resources described by `apps.hjson`:
+
+```bash
+make area=apps pulumi-update
 ```
 
 #### Delete
@@ -248,6 +275,24 @@ Config:
 
 - `area/do/do.hjson`
 
+#### Cluster defaults
+
+The DigitalOcean program creates the cluster VPC and then provisions the cluster with fixed
+operational defaults:
+
+- Region: `fra1`
+- Kubernetes version: pinned in code
+- Node count: `2`
+- Maintenance window: any day at `23:00`
+- Associated resources: destroyed with the cluster
+
+Cluster `resource` values map to node capacity:
+
+- `"small"` (default): 2 vCPU / 4 GB node
+- `"medium"`: 4 vCPU / 8 GB node
+
+Unknown or empty values fall back to `"small"`.
+
 #### Manual prerequisites (DigitalOcean UI)
 
 Some items may be created manually depending on account setup:
@@ -258,11 +303,7 @@ Some items may be created manually depending on account setup:
 | ------------- | ------------------------------------- |
 | lean-thoughts | All of experiments for lean-thoughts. |
 
-- A default VPC in your target region (example):
-
-| Name         | Description               |
-| ------------ | ------------------------- |
-| default-fra1 | The default vpc for fra1. |
+The Pulumi program creates the VPC used by the cluster and attaches the cluster to it.
 
 #### Kubernetes cluster upgrades
 
@@ -317,6 +358,9 @@ pages: {
 
 ##### Collaborators
 
+When enabled, collaborator management grants `admin` permission to `lean-thoughts-ci`
+on `alexfalkowski/<repository>`.
+
 First change:
 
 ```hjson
@@ -362,7 +406,6 @@ make -C area/k8s pods
 Depending on what you install, the k8s add-ons Makefile expects secrets like:
 
 - `CIRCLECI_K8S_TOKEN` (CircleCI release agent)
-- `BETTER_STACK_COLLECTOR_SECRET` (Better Stack collector)
 
 Because the Makefile is a local-operator workflow, the CircleCI release-agent token is passed
 directly to Helm rather than through a CI secret-handling path.

--- a/api/infraops/v2/service.pb.go
+++ b/api/infraops/v2/service.pb.go
@@ -115,9 +115,12 @@ type Application struct {
 	Name string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
 	// Namespace is the Kubernetes namespace to deploy into.
 	Namespace string `protobuf:"bytes,4,opt,name=namespace,proto3" json:"namespace,omitempty"`
-	// Domain is the external DNS name/host used for ingress routing (for example "api.example.com").
+	// Domain is the base/apex domain suffix used for ingress routing (for example "example.com").
+	// The apps program creates ingress hosts as "<name>.<domain>".
 	Domain string `protobuf:"bytes,5,opt,name=domain,proto3" json:"domain,omitempty"`
-	// Version is the application version to deploy (for example a container image tag).
+	// Version is the semantic application version to deploy.
+	// Internal app image tags are built as "v<version>", while external app image tags use
+	// "<version>" directly.
 	Version string `protobuf:"bytes,6,opt,name=version,proto3" json:"version,omitempty"`
 	// Resource selects the resource profile to apply to the application pod.
 	//
@@ -126,18 +129,19 @@ type Application struct {
 	//
 	// If an unknown value is provided, the implementation falls back to "small".
 	Resource string `protobuf:"bytes,7,opt,name=resource,proto3" json:"resource,omitempty"`
-	// Secrets is a list of logical secret names referenced by this application.
+	// Secrets is a list of existing logical secret names referenced by this application.
 	//
 	// Clarification:
-	//   - This field is an application-level dependency list used by the deployment implementation to
-	//     provision and/or wire Secret resources (for example as volumes or other attachments).
+	//   - This field is an application-level dependency list used by the deployment implementation
+	//     to wire Secret resources as volumes.
 	//   - This list is related to, but distinct from, secret references in EnvVars:
 	//   - EnvVar values of the form "secret:<secretName>/<key>" reference a specific key within a secret.
 	//   - This Secrets list enumerates which logical secrets the application depends on (often the
 	//     same <secretName> values), but does not by itself specify which keys are consumed.
 	//
-	// In the current implementation, these names are typically materialized as Kubernetes Secrets
-	// with a "-secret" suffix and are used for volume/env wiring where applicable.
+	// The apps program does not create Secret objects or define Secret keys. For internal apps, each
+	// name is expected to exist as a Kubernetes Secret named "<secretName>-secret" and is mounted at
+	// "/etc/secrets/<secretName>".
 	Secrets []string `protobuf:"bytes,8,rep,name=secrets,proto3" json:"secrets,omitempty"`
 	// EnvVars is the list of environment variables to inject into the application container.
 	EnvVars       []*EnvVar `protobuf:"bytes,9,rep,name=env_vars,json=envVars,proto3" json:"env_vars,omitempty"`
@@ -295,7 +299,8 @@ func (x *Kubernetes) GetApplications() []*Application {
 
 // Collaborators toggles whether repository collaborators are managed for a repository.
 //
-// When enabled, the infra code may create collaborator resources (for example for CI users).
+// When enabled, the infra code grants "admin" permission to "lean-thoughts-ci" on
+// "alexfalkowski/<repository>".
 type Collaborators struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Enabled controls whether collaborator resources should be created/managed.
@@ -344,6 +349,7 @@ func (x *Collaborators) GetEnabled() bool {
 // Template identifies a GitHub template repository.
 //
 // When provided, a repository may be created from this template rather than as a blank repository.
+// If template is present, owner and repository must both be non-empty.
 type Template struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Owner is the organization or user that owns the template repository.
@@ -479,9 +485,10 @@ type Repository struct {
 	Pages *Pages `protobuf:"bytes,9,opt,name=pages,proto3" json:"pages,omitempty"`
 	// Topics is the set of repository topics to apply.
 	Topics []string `protobuf:"bytes,10,rep,name=topics,proto3" json:"topics,omitempty"`
-	// Checks is the set of required status check contexts enforced by branch protection.
+	// Checks is the set of required status check contexts enforced by branch protection on "master".
 	// Branch protection intentionally requires zero approving PR reviews because these repositories
 	// are maintained by a solo contributor, so required status checks are the primary merge gate.
+	// Status checks are enforced in strict mode.
 	//
 	// In the current implementation, an empty list is invalid and will cause provisioning to fail.
 	Checks        []string `protobuf:"bytes,11,rep,name=checks,proto3" json:"checks,omitempty"`
@@ -655,6 +662,10 @@ func (x *Github) GetRepositories() []*Repository {
 //
 // The `area/cf` Pulumi program creates the zone and then creates proxied A/AAAA records for the
 // subdomains listed in record_names.
+//
+// Created zones receive the shared Cloudflare zone-settings baseline: always_use_https on,
+// min_tls_version 1.2, cache_level aggressive, http3 on, email_obfuscation off,
+// h2_prioritization on, and ssl full.
 type BalancerZone struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Name is the Pulumi resource name prefix for resources created for this zone.
@@ -736,17 +747,17 @@ func (x *BalancerZone) GetRecordNames() []string {
 	return nil
 }
 
-// PageZone describes a Cloudflare zone used for a Cloudflare Pages site.
+// PageZone describes a Cloudflare zone used for a static-site or pages-style CNAME target.
 //
-// The infra code creates the zone (with strict SSL mode) and creates a proxied CNAME from
-// "www.<domain>" to host.
+// The infra code creates the zone, applies the shared Cloudflare zone-settings baseline with
+// ssl strict, and creates a proxied CNAME from "www.<domain>" to host.
 type PageZone struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Name is the Pulumi resource name prefix for resources created for this zone.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// Domain is the apex domain for the zone (for example "example.com").
 	Domain string `protobuf:"bytes,2,opt,name=domain,proto3" json:"domain,omitempty"`
-	// Host is the Cloudflare Pages hostname to CNAME to (for example "<project>.pages.dev").
+	// Host is the DNS hostname to CNAME to (for example "<owner>.github.io" or "<project>.pages.dev").
 	Host          string `protobuf:"bytes,3,opt,name=host,proto3" json:"host,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1008,7 +1019,13 @@ type Cluster struct {
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// Description is an optional description (used for related resources such as the VPC).
 	Description string `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
-	// Resource is a size label (for example "small" or "medium") used to select a droplet size slug.
+	// Resource is a size label used to select the DigitalOcean node capacity.
+	//
+	// Current mapping:
+	//   - "small" (default): 2 vCPU / 4 GB node
+	//   - "medium": 4 vCPU / 8 GB node
+	//
+	// Unknown or empty values fall back to "small".
 	Resource      string `protobuf:"bytes,3,opt,name=resource,proto3" json:"resource,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/api/infraops/v2/service.proto
+++ b/api/infraops/v2/service.proto
@@ -54,10 +54,13 @@ message Application {
   // Namespace is the Kubernetes namespace to deploy into.
   string namespace = 4;
 
-  // Domain is the external DNS name/host used for ingress routing (for example "api.example.com").
+  // Domain is the base/apex domain suffix used for ingress routing (for example "example.com").
+  // The apps program creates ingress hosts as "<name>.<domain>".
   string domain = 5;
 
-  // Version is the application version to deploy (for example a container image tag).
+  // Version is the semantic application version to deploy.
+  // Internal app image tags are built as "v<version>", while external app image tags use
+  // "<version>" directly.
   string version = 6;
 
   // Resource selects the resource profile to apply to the application pod.
@@ -68,18 +71,19 @@ message Application {
   // If an unknown value is provided, the implementation falls back to "small".
   string resource = 7;
 
-  // Secrets is a list of logical secret names referenced by this application.
+  // Secrets is a list of existing logical secret names referenced by this application.
   //
   // Clarification:
-  //   - This field is an application-level dependency list used by the deployment implementation to
-  //     provision and/or wire Secret resources (for example as volumes or other attachments).
+  //   - This field is an application-level dependency list used by the deployment implementation
+  //     to wire Secret resources as volumes.
   //   - This list is related to, but distinct from, secret references in EnvVars:
   //       - EnvVar values of the form "secret:<secretName>/<key>" reference a specific key within a secret.
   //       - This Secrets list enumerates which logical secrets the application depends on (often the
   //         same <secretName> values), but does not by itself specify which keys are consumed.
   //
-  // In the current implementation, these names are typically materialized as Kubernetes Secrets
-  // with a "-secret" suffix and are used for volume/env wiring where applicable.
+  // The apps program does not create Secret objects or define Secret keys. For internal apps, each
+  // name is expected to exist as a Kubernetes Secret named "<secretName>-secret" and is mounted at
+  // "/etc/secrets/<secretName>".
   repeated string secrets = 8;
 
   // EnvVars is the list of environment variables to inject into the application container.
@@ -97,7 +101,8 @@ message Kubernetes {
 
 // Collaborators toggles whether repository collaborators are managed for a repository.
 //
-// When enabled, the infra code may create collaborator resources (for example for CI users).
+// When enabled, the infra code grants "admin" permission to "lean-thoughts-ci" on
+// "alexfalkowski/<repository>".
 message Collaborators {
   // Enabled controls whether collaborator resources should be created/managed.
   bool enabled = 1;
@@ -106,6 +111,7 @@ message Collaborators {
 // Template identifies a GitHub template repository.
 //
 // When provided, a repository may be created from this template rather than as a blank repository.
+// If template is present, owner and repository must both be non-empty.
 message Template {
   // Owner is the organization or user that owns the template repository.
   string owner = 1;
@@ -158,9 +164,10 @@ message Repository {
   // Topics is the set of repository topics to apply.
   repeated string topics = 10;
 
-  // Checks is the set of required status check contexts enforced by branch protection.
+  // Checks is the set of required status check contexts enforced by branch protection on "master".
   // Branch protection intentionally requires zero approving PR reviews because these repositories
   // are maintained by a solo contributor, so required status checks are the primary merge gate.
+  // Status checks are enforced in strict mode.
   //
   // In the current implementation, an empty list is invalid and will cause provisioning to fail.
   repeated string checks = 11;
@@ -179,6 +186,10 @@ message Github {
 //
 // The `area/cf` Pulumi program creates the zone and then creates proxied A/AAAA records for the
 // subdomains listed in record_names.
+//
+// Created zones receive the shared Cloudflare zone-settings baseline: always_use_https on,
+// min_tls_version 1.2, cache_level aggressive, http3 on, email_obfuscation off,
+// h2_prioritization on, and ssl full.
 message BalancerZone {
   // Name is the Pulumi resource name prefix for resources created for this zone.
   string name = 1;
@@ -196,10 +207,10 @@ message BalancerZone {
   repeated string record_names = 5;
 }
 
-// PageZone describes a Cloudflare zone used for a Cloudflare Pages site.
+// PageZone describes a Cloudflare zone used for a static-site or pages-style CNAME target.
 //
-// The infra code creates the zone (with strict SSL mode) and creates a proxied CNAME from
-// "www.<domain>" to host.
+// The infra code creates the zone, applies the shared Cloudflare zone-settings baseline with
+// ssl strict, and creates a proxied CNAME from "www.<domain>" to host.
 message PageZone {
   // Name is the Pulumi resource name prefix for resources created for this zone.
   string name = 1;
@@ -207,7 +218,7 @@ message PageZone {
   // Domain is the apex domain for the zone (for example "example.com").
   string domain = 2;
 
-  // Host is the Cloudflare Pages hostname to CNAME to (for example "<project>.pages.dev").
+  // Host is the DNS hostname to CNAME to (for example "<owner>.github.io" or "<project>.pages.dev").
   string host = 3;
 }
 
@@ -261,7 +272,13 @@ message Cluster {
   // Description is an optional description (used for related resources such as the VPC).
   string description = 2;
 
-  // Resource is a size label (for example "small" or "medium") used to select a droplet size slug.
+  // Resource is a size label used to select the DigitalOcean node capacity.
+  //
+  // Current mapping:
+  //   - "small" (default): 2 vCPU / 4 GB node
+  //   - "medium": 4 vCPU / 8 GB node
+  //
+  // Unknown or empty values fall back to "small".
   string resource = 3;
 }
 

--- a/internal/app/resource.go
+++ b/internal/app/resource.go
@@ -39,10 +39,10 @@ var resources = ResourcesMap{
 	},
 }
 
-// ResourcesMap got app.
+// ResourcesMap maps configuration resource profile names to Kubernetes request/limit ranges.
 type ResourcesMap map[string]*Resources
 
-// Resources by name if found, otherwise small.
+// Resources returns the named resource profile, or the small profile when name is unknown.
 func (r ResourcesMap) Resources(name string) *Resources {
 	res, ok := r[name]
 	if ok {

--- a/internal/app/version/doc.go
+++ b/internal/app/version/doc.go
@@ -1,0 +1,5 @@
+// Package version updates application versions in the apps HJSON configuration.
+//
+// It backs the internal bump automation used to update a single configured application version
+// while preserving the repository's canonical config format.
+package version

--- a/internal/cf/balancer.go
+++ b/internal/cf/balancer.go
@@ -42,6 +42,9 @@ func ConvertBalancerZone(z *v2.BalancerZone) *BalancerZone {
 }
 
 // CreateBalancerZone provisions a Cloudflare zone and creates proxied A and AAAA records.
+//
+// It applies the shared zone-settings baseline with "full" SSL mode, then creates A and AAAA
+// records for each configured record name under the zone domain.
 func CreateBalancerZone(ctx *pulumi.Context, zone *BalancerZone) error {
 	z, err := createZone(ctx, zone.Name, zone.Domain, "full")
 	if err != nil {

--- a/internal/cf/cf.go
+++ b/internal/cf/cf.go
@@ -35,10 +35,12 @@ type ZoneSetting struct {
 	Value pulumi.String
 }
 
-// settings applies a baseline set of Cloudflare zone settings to the given zone.
+// settings applies the shared Cloudflare zone-settings baseline to the given zone.
 //
 // The resource names are derived from the provided name plus the setting identifier to keep
-// them stable across updates. The ssl argument is applied to the zone "ssl" setting.
+// them stable across updates. The baseline enables always_use_https, min_tls_version 1.2,
+// cache_level aggressive, http3, and h2_prioritization; disables email_obfuscation; and uses
+// ssl as the value for the zone "ssl" setting.
 func settings(ctx *pulumi.Context, name, ssl string, cz *cloudflare.Zone) error {
 	settings := []*ZoneSetting{
 		{Name: "always_use_https", Value: inputs.On},

--- a/internal/cf/page.go
+++ b/internal/cf/page.go
@@ -9,13 +9,13 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-// PageZone describes a Cloudflare Pages-backed zone and the DNS configuration required for it.
+// PageZone describes a Cloudflare zone used for a static-site or pages-style CNAME target.
 type PageZone struct {
 	// Name is the Pulumi resource name prefix used when creating Cloudflare resources for this zone.
 	Name string
 	// Domain is the apex domain to create/manage as a Cloudflare zone (for example "example.com").
 	Domain string
-	// Host is the Cloudflare Pages hostname to CNAME to (for example "<project>.pages.dev").
+	// Host is the DNS hostname to CNAME to (for example "<owner>.github.io" or "<project>.pages.dev").
 	Host string
 }
 
@@ -28,10 +28,10 @@ func ConvertPageZone(z *v2.PageZone) *PageZone {
 	}
 }
 
-// CreatePageZone provisions a Cloudflare zone for a Pages site and creates a proxied CNAME record.
+// CreatePageZone provisions a Cloudflare zone for a static-site CNAME target.
 //
-// It creates the zone with "strict" SSL mode and then creates a CNAME from "www.<domain>"
-// to zone.Host. The DNS record is proxied and uses Cloudflare's automatic TTL.
+// It applies the shared zone-settings baseline with "strict" SSL mode, then creates a proxied
+// CNAME from "www.<domain>" to zone.Host using Cloudflare's automatic TTL.
 func CreatePageZone(ctx *pulumi.Context, zone *PageZone) error {
 	z, err := createZone(ctx, zone.Name, zone.Domain, "strict")
 	if err != nil {

--- a/internal/do/do.go
+++ b/internal/do/do.go
@@ -29,13 +29,14 @@ type Cluster struct {
 	Name string
 	// Description is an optional description for cluster-related resources (for example the VPC).
 	Description string
-	// Resource is a size label (for example "small" or "medium") used to select a droplet size slug.
+	// Resource is a size label (for example "small" or "medium") used to select node capacity.
 	Resource string
 }
 
 // Size returns the DigitalOcean droplet size slug selected by c.Resource.
 //
-// If c.Resource is not recognized, Size returns a sensible default.
+// Supported labels are "small" (2 vCPU / 4 GB) and "medium" (4 vCPU / 8 GB). If c.Resource
+// is not recognized, Size returns the small default.
 func (c *Cluster) Size() digitalocean.DropletSlug {
 	if s, ok := sizes[c.Resource]; ok {
 		return s
@@ -54,7 +55,9 @@ func ConvertCluster(cluster *v2.Cluster) *Cluster {
 
 // CreateCluster provisions the networking and Kubernetes cluster resources for cluster.
 //
-// It creates a VPC and then creates a Kubernetes cluster attached to that VPC.
+// It creates a VPC in fra1, then creates a Kubernetes cluster attached to that VPC. The cluster
+// uses two nodes, the Kubernetes version pinned in code, maintenance start time 23:00 on any day,
+// and DestroyAllAssociatedResources enabled.
 func CreateCluster(ctx *pulumi.Context, cluster *Cluster) (err error) {
 	v, err := createVPC(ctx, cluster)
 	if err != nil {

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -106,8 +106,9 @@ func ConvertRepository(r *v2.Repository) *Repository {
 // CreateRepository provisions and configures a GitHub repository.
 //
 // It creates (or updates) the repository and then applies additional repository configuration
-// such as branch protection and collaborators. Errors are wrapped with the repository name
-// to make failures easier to identify in Pulumi output.
+// such as branch protection, always-on security settings, vulnerability alerts, Pages, and
+// collaborators. Errors are wrapped with the repository name to make failures easier to identify
+// in Pulumi output.
 func CreateRepository(ctx *pulumi.Context, repo *Repository) error {
 	r, err := repository(ctx, repo)
 	if err != nil {
@@ -130,8 +131,11 @@ type (
 	Visibility string
 
 	// Collaborators describes whether collaborator management is enabled for a repository.
+	//
+	// When enabled, the implementation grants admin permission to lean-thoughts-ci on
+	// alexfalkowski/<repository>.
 	Collaborators struct {
-		// Enabled controls whether collaborators should be managed for the repository.
+		// Enabled controls whether the fixed admin collaborator should be managed for the repository.
 		Enabled bool
 	}
 
@@ -147,6 +151,7 @@ type (
 // Repository describes a GitHub repository and its desired configuration.
 type Repository struct {
 	// Collaborators is optional; when nil or disabled, collaborator resources are not managed.
+	// When enabled, lean-thoughts-ci is granted admin permission on alexfalkowski/<repository>.
 	Collaborators *Collaborators
 	// Template is optional; when set, it identifies the template repository used on creation.
 	Template *Template

--- a/internal/gh/repository.go
+++ b/internal/gh/repository.go
@@ -9,7 +9,8 @@ import (
 // repository creates or updates a GitHub repository and applies the baseline repository settings.
 //
 // It validates repo.Checks (required for branch protection) and, when configured, attaches a
-// repository template and GitHub Pages configuration.
+// repository template and GitHub Pages configuration. Secret scanning, push protection, and
+// vulnerability alerts are enabled for every repository.
 func repository(ctx *pulumi.Context, repo *Repository) (*github.Repository, error) {
 	t, err := template(repo)
 	if err != nil {

--- a/internal/test/stub.go
+++ b/internal/test/stub.go
@@ -28,6 +28,9 @@ func (*Stub) NewResource(args pulumi.MockResourceArgs) (string, resource.Propert
 }
 
 // ResourceStub is a pulumi.Mocks implementation that records created resource inputs by type token.
+//
+// Resource attempts are recorded before any configured failure is returned, so Resources includes
+// failed attempts as well as successful ones.
 type ResourceStub struct {
 	Stub
 
@@ -83,6 +86,9 @@ func (s *ResourceStub) FailResourceAtWith(token string, occurrence int, err erro
 }
 
 // NewResource records the resource inputs by Pulumi type token and returns the inputs unchanged.
+//
+// If a failure is configured for the resource type or occurrence, the attempt is still recorded
+// before the error is returned.
 func (s *ResourceStub) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
 	s.mu.Lock()
 


### PR DESCRIPTION
## What

- Clarify configuration contracts for apps, GitHub, Cloudflare, and DigitalOcean resources.
- Document operator tooling, Pulumi refresh, CI workflow behavior, and package/resource GoDocs.
- Regenerate protobuf Go comments from the updated schema docs.

## Why

- Keep operator-facing docs aligned with the actual Pulumi implementation and avoid stale or misleading configuration guidance.

## Testing

- `make dep` - passed
- `make api-generate` - passed
- `make api-lint` - passed
- `make api-breaking` - passed
- `make lint` - passed
- `make specs` - passed
- `git diff --check` - passed
