### PR TITLE
feat(style): polish repository readability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,8 @@ matching skill for the task.
 
 ## Baseline
 
-- This repo is a Go/Pulumi infra monorepo. Each Pulumi area lives in `area/<name>/` with `main.go`, `Pulumi.yaml`, and `<name>.hjson`.
+- This repo is a Go/Pulumi infra monorepo.
+- Each Pulumi area lives in `area/<name>/` with `main.go`, `Pulumi.yaml`, and `<name>.hjson`.
 - Shared implementation lives in `internal/`; config schema lives in `api/infraops/v2/service.proto`; generated Go lives in `api/infraops/v2/service.pb.go`.
 - Keep package-level GoDocs in `doc.go` files. Do not scatter package comments across implementation files.
 

--- a/Makefile
+++ b/Makefile
@@ -2,27 +2,27 @@ include bin/build/make/help.mak
 include bin/build/make/go.mak
 include bin/build/make/git.mak
 
-# Log into pulumi.
+# Log into Pulumi.
 pulumi-login:
 	@pulumi login --cloud-url https://api.pulumi.com
 
-# Preview pulumi changes.
+# Preview Pulumi changes.
 pulumi-preview:
 	@pulumi preview --stack alexfalkowski/$(area)/prod --cwd area/$(area) --diff
 
-# Update pulumi changes.
+# Update Pulumi changes.
 pulumi-update:
 	@pulumi update --yes --stack alexfalkowski/$(area)/prod --cwd area/$(area)
 
-# Cancel pulumi changes.
+# Cancel Pulumi changes.
 pulumi-cancel:
 	@pulumi cancel --yes --stack alexfalkowski/$(area)/prod --cwd area/$(area)
 
-# Delete pulumi stack.
+# Delete Pulumi stack.
 pulumi-delete:
 	@pulumi stack rm --yes --force --stack alexfalkowski/$(area)/prod --cwd area/$(area)
 
-# Refresh pulumi stack.
+# Refresh Pulumi stack.
 pulumi-refresh:
 	@pulumi refresh --yes --stack alexfalkowski/$(area)/prod --cwd area/$(area)
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Those protobuf messages are then converted into internal Go types and used to pr
 ### Format and normalize config
 
 This repo includes a small CLI to normalize/format config files by:
-1) decoding the HJSON into the appropriate protobuf message
-2) writing it back out in a canonical form
+1. decoding the HJSON into the appropriate protobuf message
+2. writing it back out in a canonical form
 
 Build:
 
@@ -301,7 +301,7 @@ Some items may be created manually depending on account setup:
 
 | Name          | Description                           |
 | ------------- | ------------------------------------- |
-| lean-thoughts | All of experiments for lean-thoughts. |
+| lean-thoughts | All experiments for lean-thoughts. |
 
 The Pulumi program creates the VPC used by the cluster and attaches the cluster to it.
 

--- a/api/infraops/v2/service.pb.go
+++ b/api/infraops/v2/service.pb.go
@@ -12,7 +12,7 @@
 //
 // Notes:
 // - This schema is intentionally configuration-oriented (it models desired state, not provider API objects).
-// - For each top-level configuration message, `version` is a config/schema version string used by tooling;
+// - For each top-level configuration message, `version` is a configuration schema version string used by tooling;
 //   it is not necessarily the same as a runtime, provider, or Kubernetes version.
 
 package v2

--- a/api/infraops/v2/service.proto
+++ b/api/infraops/v2/service.proto
@@ -8,7 +8,7 @@ syntax = "proto3";
 //
 // Notes:
 // - This schema is intentionally configuration-oriented (it models desired state, not provider API objects).
-// - For each top-level configuration message, `version` is a config/schema version string used by tooling;
+// - For each top-level configuration message, `version` is a configuration schema version string used by tooling;
 //   it is not necessarily the same as a runtime, provider, or Kubernetes version.
 package infraops.v2;
 

--- a/area/apps/lean.mk
+++ b/area/apps/lean.mk
@@ -1,4 +1,4 @@
-# Run kubescore for lean.
+# Run kube-score for lean.
 kube-score-lean:
 	@kubectl api-resources --verbs=list --namespaced -o name \
 		| xargs -I{} bash -c "kubectl get {} --namespace lean -oyaml && echo ---" \
@@ -12,7 +12,7 @@ kubescape-lean:
 delete-lean:
 	@kubectl delete namespaces lean
 
-# Create lean
+# Create lean.
 create-lean:
 	@kubectl create namespace lean
 
@@ -39,11 +39,11 @@ verify-lean: verify-standort verify-bezeichner verify-web
 
 # Verify standort.
 verify-standort:
-	@curl -svf --header "Content-Type: application/json" --request POST --data {}  https://standort.lean-thoughts.com/standort.v2.Service/GetLocation
+	@curl -svf --header "Content-Type: application/json" --request POST --data {} https://standort.lean-thoughts.com/standort.v2.Service/GetLocation
 
 # Verify bezeichner.
 verify-bezeichner:
-	@curl -svf --header "Content-Type: application/json" --request POST --data '{ "application": "ulid", "count": 10 }'  https://bezeichner.lean-thoughts.com/bezeichner.v1.Service/GenerateIdentifiers
+	@curl -svf --header "Content-Type: application/json" --request POST --data '{ "application": "ulid", "count": 10 }' https://bezeichner.lean-thoughts.com/bezeichner.v1.Service/GenerateIdentifiers
 
 # Verify web.
 verify-web:

--- a/area/apps/lean/bezeichner.json
+++ b/area/apps/lean/bezeichner.json
@@ -1,1 +1,4 @@
-{ "application": "uuid", "count": 10 }
+{
+  "application": "uuid",
+  "count": 10
+}

--- a/area/gh/gh.hjson
+++ b/area/gh/gh.hjson
@@ -3,7 +3,7 @@
   repositories: [
     {
       name: nonnative
-      description: Allows you to keep using the power of ruby to test other systems.
+      description: Allows you to keep using the power of Ruby to test other systems.
       homepage_url: https://alexfalkowski.github.io/nonnative
       visibility: public
       collaborators: {
@@ -23,7 +23,7 @@
     }
     {
       name: go-service
-      description: A framework to build services in go.
+      description: A framework to build services in Go.
       homepage_url: https://alexfalkowski.github.io/go-service
       visibility: public
       collaborators: {
@@ -49,7 +49,7 @@
     }
     {
       name: go-health
-      description: Health monitoring pattern in go.
+      description: Health monitoring pattern in Go.
       homepage_url: https://alexfalkowski.github.io/go-health
       visibility: public
       collaborators: {
@@ -186,7 +186,7 @@
     }
     {
       name: go-client-template
-      description: A template for go clients.
+      description: A template for Go clients.
       homepage_url: https://alexfalkowski.github.io/go-client-template
       visibility: public
       is_template: true
@@ -212,7 +212,7 @@
     }
     {
       name: go-service-template
-      description: A template for go services.
+      description: A template for Go services.
       homepage_url: https://alexfalkowski.github.io/go-service-template
       visibility: public
       is_template: true

--- a/area/k8s/Makefile
+++ b/area/k8s/Makefile
@@ -2,21 +2,21 @@
 save-config:
 	@doctl kubernetes cluster kubeconfig save e18082d3-d874-4e84-8703-c15e6d6fea3a
 
-# Delete all.
+# Delete add-on namespaces.
 delete:
 	@kubectl delete namespaces nginx-ingress circleci metrics-server
 
-# Setup everything.
+# Set up Helm repos and install add-ons.
 setup: setup-helm install-helm
 
-# Setup helm repos.
+# Set up Helm repos.
 setup-helm:
 	@helm repo add nginx https://kubernetes.github.io/ingress-nginx
 	@helm repo add circleci https://circleci-public.github.io/cci-k8s-release-agent
 	@helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
 	@helm repo update
 
-# Install circleci. This target is run manually from an operator workstation, not CI.
+# Install CircleCI. This target is run manually from an operator workstation, not CI.
 install-circleci:
 	@helm upgrade --install circleci-release circleci/circleci-release-agent --set tokenSecret.token=$(CIRCLECI_K8S_TOKEN) --create-namespace --namespace circleci --set managedNamespaces="{lean}" --version 1.5.0
 
@@ -28,9 +28,9 @@ install-metrics-server:
 install-nginx-ingress:
 	@helm upgrade --install nginx-ingress-release nginx/ingress-nginx --namespace nginx-ingress --create-namespace --version 4.14.3 -f nginx/values.yaml
 
-# Install helm.
+# Install Helm add-ons.
 install-helm: install-circleci install-metrics-server install-nginx-ingress
 
-# All pods.
+# List all pods.
 pods:
 	@kubectl get pods --all-namespaces

--- a/cmd/bump/bump.go
+++ b/cmd/bump/bump.go
@@ -17,9 +17,9 @@ func run() error {
 	)
 
 	set := flag.NewFlagSet("bump", flag.ContinueOnError)
-	set.StringVar(&name, "n", "", "name of the app")
-	set.StringVar(&ver, "v", "", "version of the app")
-	set.StringVar(&path, "p", "", "path of the config")
+	set.StringVar(&name, "n", "", "application name")
+	set.StringVar(&ver, "v", "", "application version")
+	set.StringVar(&path, "p", "", "config file path")
 	if err := set.Parse(os.Args[1:]); err != nil {
 		return err
 	}

--- a/cmd/format/format.go
+++ b/cmd/format/format.go
@@ -30,8 +30,8 @@ func run() error {
 	)
 
 	set := flag.NewFlagSet("format", flag.ContinueOnError)
-	set.StringVar(&kind, "k", "", "kind of config")
-	set.StringVar(&path, "p", "", "path of the config")
+	set.StringVar(&kind, "k", "", "config kind")
+	set.StringVar(&path, "p", "", "config file path")
 	if err := set.Parse(os.Args[1:]); err != nil {
 		return err
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -38,9 +38,12 @@ func WriteConfiguration(path string, configuration *v2.Kubernetes) error {
 // structures that are later used to create Kubernetes resources.
 func ConvertApplication(a *v2.Application) *App {
 	app := &App{
-		ID: a.GetId(), Kind: a.GetKind(),
-		Name: a.GetName(), Namespace: a.GetNamespace(),
-		Domain: a.GetDomain(), Version: a.GetVersion(),
+		ID:        a.GetId(),
+		Kind:      a.GetKind(),
+		Name:      a.GetName(),
+		Namespace: a.GetNamespace(),
+		Domain:    a.GetDomain(),
+		Version:   a.GetVersion(),
 		Resources: resources.Resources(a.GetResource()),
 		Secrets:   a.GetSecrets(),
 	}
@@ -67,13 +70,13 @@ func ConvertApplication(a *v2.Application) *App {
 // Resources are created in a fixed order to ensure dependencies exist (for example,
 // ServiceAccount before Deployment). Any error aborts the creation flow and is returned.
 func CreateApplication(ctx *pulumi.Context, app *App) error {
-	fns := []func(ctx *pulumi.Context, app *App) error{
+	resourceCreators := []func(ctx *pulumi.Context, app *App) error{
 		createServiceAccount, createNetworkPolicy,
 		createConfigMap, createPodDisruptionBudget,
 		createDeployment, createService, createIngress,
 	}
-	for _, fn := range fns {
-		if err := fn(ctx, app); err != nil {
+	for _, createResource := range resourceCreators {
+		if err := createResource(ctx, app); err != nil {
 			return err
 		}
 	}
@@ -105,7 +108,7 @@ type App struct {
 	EnvVars []*EnvVar
 }
 
-// HasResources reports whether a has resource requirements configured.
+// HasResources reports whether the application has resource requirements configured.
 func (a *App) HasResources() bool {
 	return a.Resources != nil
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -26,8 +26,8 @@ func TestApp(t *testing.T) {
 		app  *app.App
 		name string
 	}{
-		{name: "with resource", app: withResource()},
-		{name: "without resource", app: withoutResource()},
+		{name: "with resource", app: appWithResources()},
+		{name: "without resource", app: appWithoutResources()},
 	}
 
 	for _, tt := range tests {
@@ -78,7 +78,7 @@ func TestApplicationReturnsResourceErrors(t *testing.T) {
 			stub.FailResource(tt.resourceType)
 
 			run := func(ctx *pulumi.Context) error {
-				return app.CreateApplication(ctx, withResource())
+				return app.CreateApplication(ctx, appWithResources())
 			}
 
 			require.Error(t, pulumi.RunErr(run, pulumi.WithMocks("project", "stack", stub)))
@@ -89,7 +89,7 @@ func TestApplicationReturnsResourceErrors(t *testing.T) {
 
 func TestApplicationReturnsMissingConfigError(t *testing.T) {
 	stub := &test.ResourceStub{}
-	application := withResource()
+	application := appWithResources()
 	application.Namespace = "missing-config-fixture"
 
 	run := func(ctx *pulumi.Context) error {
@@ -132,7 +132,8 @@ func TestConvertedApplicationDeploymentInputs(t *testing.T) {
 	require.Equal(t, "2Gi", resourceLimit(deployment, "ephemeral-storage"))
 
 	secret := envVar(deployment, "DATABASE_PASSWORD")
-	secretKeyRef := test.Property(t, test.Property(t, secret, "valueFrom").ObjectValue(), "secretKeyRef").ObjectValue()
+	valueFrom := test.Property(t, secret, "valueFrom").ObjectValue()
+	secretKeyRef := test.Property(t, valueFrom, "secretKeyRef").ObjectValue()
 	require.Equal(t, "database-secret", test.Property(t, secretKeyRef, "name").StringValue())
 	require.Equal(t, "password", test.Property(t, secretKeyRef, "key").StringValue())
 }
@@ -163,7 +164,7 @@ func TestExternalApplicationOmitsInternalResources(t *testing.T) {
 	require.NotContains(t, container(deployment), resource.PropertyKey("volumeMounts"))
 }
 
-func withResource() *app.App {
+func appWithResources() *app.App {
 	return &app.App{
 		ID:        "1234",
 		Kind:      "internal",
@@ -183,7 +184,7 @@ func withResource() *app.App {
 	}
 }
 
-func withoutResource() *app.App {
+func appWithoutResources() *app.App {
 	return &app.App{
 		ID:        "1234",
 		Name:      "test",

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -23,14 +23,14 @@ func createConfigMap(ctx *pulumi.Context, app *App) error {
 }
 
 func configMap(app *App) (*cv1.ConfigMapArgs, error) {
-	d, err := readFile(app.Namespace, app.Name+".yaml")
+	configData, err := readFile(app.Namespace, app.Name+".yaml")
 	if err != nil {
 		return nil, err
 	}
 
 	args := &cv1.ConfigMapArgs{
 		Metadata: metadata(app),
-		Data:     pulumi.StringMap{configFile(app.Name): pulumi.String(d)},
+		Data:     pulumi.StringMap{configFile(app.Name): pulumi.String(configData)},
 	}
 	return args, nil
 }
@@ -52,13 +52,13 @@ func configFile(name string) string {
 }
 
 func readFile(ns, file string) (string, error) {
-	p, err := filePath(ns, file)
+	path, err := filePath(ns, file)
 	if err != nil {
 		return "", err
 	}
 
-	d, err := os.ReadFile(filepath.Clean(p))
-	return string(d), err
+	data, err := os.ReadFile(filepath.Clean(path))
+	return string(data), err
 }
 
 func filePath(ns, file string) (string, error) {

--- a/internal/app/environment.go
+++ b/internal/app/environment.go
@@ -11,14 +11,14 @@ func addEnvironments(app *App, envs cv1.EnvVarArray) cv1.EnvVarArray {
 	for _, envVar := range app.EnvVars {
 		var arg cv1.EnvVarArgs
 		if envVar.IsSecret() {
-			value := strings.TrimPrefix(envVar.Value, "secret:")
-			name, value, _ := strings.Cut(value, "/")
+			secretRef := strings.TrimPrefix(envVar.Value, "secret:")
+			secretName, secretKey, _ := strings.Cut(secretRef, "/")
 			arg = cv1.EnvVarArgs{
 				Name: pulumi.String(envVar.Name),
 				ValueFrom: &cv1.EnvVarSourceArgs{
 					SecretKeyRef: &cv1.SecretKeySelectorArgs{
-						Name: pulumi.String(name + secretSuffix),
-						Key:  pulumi.String(value),
+						Name: pulumi.String(secretName + secretSuffix),
+						Key:  pulumi.String(secretKey),
 					},
 				},
 			}

--- a/internal/app/metadata.go
+++ b/internal/app/metadata.go
@@ -8,12 +8,12 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-func metadata(app *App, ms ...pulumi.StringMap) mv1.ObjectMetaArgs {
-	ms = append(ms, recommendedLabels(app))
+func metadata(app *App, labelMaps ...pulumi.StringMap) mv1.ObjectMetaArgs {
+	labelMaps = append(labelMaps, recommendedLabels(app))
 	return mv1.ObjectMetaArgs{
 		Name:      pulumi.String(app.Name),
 		Namespace: pulumi.String(app.Namespace),
-		Labels:    merge(ms...),
+		Labels:    merge(labelMaps...),
 	}
 }
 
@@ -57,10 +57,10 @@ func deploymentAnnotations(app *App) pulumi.StringMap {
 	}
 }
 
-func merge(ms ...pulumi.StringMap) pulumi.StringMap {
-	fm := pulumi.StringMap{}
-	for _, m := range ms {
-		maps.Copy(fm, m)
+func merge(labelMaps ...pulumi.StringMap) pulumi.StringMap {
+	merged := pulumi.StringMap{}
+	for _, labels := range labelMaps {
+		maps.Copy(merged, labels)
 	}
-	return fm
+	return merged
 }

--- a/internal/cf/balancer.go
+++ b/internal/cf/balancer.go
@@ -9,8 +9,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-// prefix maps DNS record types to a stable name prefix used for Pulumi resource naming.
-var prefix = map[string]string{
+// recordPrefixes maps DNS record types to a stable prefix used for Pulumi resource naming.
+var recordPrefixes = map[string]string{
 	"A":    "ipv4",
 	"AAAA": "ipv6",
 }
@@ -51,8 +51,8 @@ func CreateBalancerZone(ctx *pulumi.Context, zone *BalancerZone) error {
 		return err
 	}
 
-	for _, n := range zone.RecordNames {
-		name := fmt.Sprintf("%s.%s", n, zone.Domain)
+	for _, recordName := range zone.RecordNames {
+		name := fmt.Sprintf("%s.%s", recordName, zone.Domain)
 
 		if err := record(ctx, name, "A", zone.IPV4, z.ID()); err != nil {
 			return err
@@ -78,7 +78,7 @@ func record(ctx *pulumi.Context, name, kind, ip string, id pulumi.IDOutput) erro
 		Proxied: inputs.Yes,
 		Ttl:     inputs.Automatic,
 	}
-	_, err := cloudflare.NewRecord(ctx, fmt.Sprintf("%s.%s", prefix[kind], name), record)
+	_, err := cloudflare.NewRecord(ctx, fmt.Sprintf("%s.%s", recordPrefixes[kind], name), record)
 
 	return err
 }

--- a/internal/cf/cf.go
+++ b/internal/cf/cf.go
@@ -57,9 +57,9 @@ func settings(ctx *pulumi.Context, name, ssl string, cz *cloudflare.Zone) error 
 			Value:     setting.Value,
 			ZoneId:    cz.ID(),
 		}
-		name := fmt.Sprintf("%s_%s", name, setting.Name)
+		resourceName := fmt.Sprintf("%s_%s", name, setting.Name)
 
-		if _, err := cloudflare.NewZoneSetting(ctx, name, args); err != nil {
+		if _, err := cloudflare.NewZoneSetting(ctx, resourceName, args); err != nil {
 			return err
 		}
 	}

--- a/internal/cf/cf_test.go
+++ b/internal/cf/cf_test.go
@@ -56,7 +56,7 @@ func TestCreateBalancerZoneReturnsResourceErrors(t *testing.T) {
 	})
 }
 
-func TestCreatePagerZone(t *testing.T) {
+func TestCreatePageZone(t *testing.T) {
 	stub := &test.ResourceStub{}
 	require.NoError(t, createPageZone(t, stub))
 	requireRecord(t, stub.Resources(recordResourceType), "CNAME", "www.test.com", "test.github.io")
@@ -67,7 +67,7 @@ func TestCreatePagerZone(t *testing.T) {
 	require.Error(t, createPageZone(t, stub))
 }
 
-func TestCreatePagerZoneReturnsRecordError(t *testing.T) {
+func TestCreatePageZoneReturnsRecordError(t *testing.T) {
 	stub := &test.ResourceStub{}
 	stub.FailResource(recordResourceType)
 
@@ -152,7 +152,7 @@ func createBalancerZone(t *testing.T, mocks pulumi.MockResourceMonitor) error {
 	t.Helper()
 
 	return test.RunWithMocks(func(ctx *pulumi.Context) error {
-		z := &cf.BalancerZone{
+		zone := &cf.BalancerZone{
 			Name:        "test",
 			Domain:      "test.com",
 			RecordNames: []string{"test"},
@@ -160,7 +160,7 @@ func createBalancerZone(t *testing.T, mocks pulumi.MockResourceMonitor) error {
 			IPV6:        "::1",
 		}
 
-		return cf.CreateBalancerZone(ctx, z)
+		return cf.CreateBalancerZone(ctx, zone)
 	}, mocks)
 }
 
@@ -168,13 +168,13 @@ func createPageZone(t *testing.T, mocks pulumi.MockResourceMonitor) error {
 	t.Helper()
 
 	return test.RunWithMocks(func(ctx *pulumi.Context) error {
-		z := &cf.PageZone{
+		zone := &cf.PageZone{
 			Name:   "test",
 			Domain: "test.com",
 			Host:   "test.github.io",
 		}
 
-		return cf.CreatePageZone(ctx, z)
+		return cf.CreatePageZone(ctx, zone)
 	}, mocks)
 }
 

--- a/internal/cf/page.go
+++ b/internal/cf/page.go
@@ -1,8 +1,6 @@
 package cf
 
 import (
-	"fmt"
-
 	v2 "github.com/alexfalkowski/infraops/v2/api/infraops/v2"
 	"github.com/alexfalkowski/infraops/v2/internal/inputs"
 	"github.com/pulumi/pulumi-cloudflare/sdk/v6/go/cloudflare"
@@ -38,8 +36,8 @@ func CreatePageZone(ctx *pulumi.Context, zone *PageZone) error {
 		return err
 	}
 
-	name := fmt.Sprintf("%s.%s", "www", zone.Domain)
-	r := &cloudflare.RecordArgs{
+	name := "www." + zone.Domain
+	args := &cloudflare.RecordArgs{
 		Type:    pulumi.String("CNAME"),
 		Name:    pulumi.String(name),
 		Content: pulumi.String(zone.Host),
@@ -47,7 +45,7 @@ func CreatePageZone(ctx *pulumi.Context, zone *PageZone) error {
 		Proxied: inputs.Yes,
 		Ttl:     inputs.Automatic,
 	}
-	_, err = cloudflare.NewRecord(ctx, name, r)
+	_, err = cloudflare.NewRecord(ctx, name, args)
 
 	return err
 }

--- a/internal/do/do.go
+++ b/internal/do/do.go
@@ -59,22 +59,22 @@ func ConvertCluster(cluster *v2.Cluster) *Cluster {
 // uses two nodes, the Kubernetes version pinned in code, maintenance start time 23:00 on any day,
 // and DestroyAllAssociatedResources enabled.
 func CreateCluster(ctx *pulumi.Context, cluster *Cluster) (err error) {
-	v, err := createVPC(ctx, cluster)
+	vpc, err := createVPC(ctx, cluster)
 	if err != nil {
 		return err
 	}
 
-	_, err = createCluster(ctx, v, cluster)
+	_, err = createCluster(ctx, vpc, cluster)
 	return err
 }
 
-func createVPC(ctx *pulumi.Context, p *Cluster) (*digitalocean.Vpc, error) {
+func createVPC(ctx *pulumi.Context, cluster *Cluster) (*digitalocean.Vpc, error) {
 	args := &digitalocean.VpcArgs{
-		Name:        pulumi.String(p.Name),
+		Name:        pulumi.String(cluster.Name),
 		Region:      digitalocean.RegionFRA1,
-		Description: pulumi.String(p.Description),
+		Description: pulumi.String(cluster.Description),
 	}
-	return digitalocean.NewVpc(ctx, p.Name, args)
+	return digitalocean.NewVpc(ctx, cluster.Name, args)
 }
 
 func createCluster(ctx *pulumi.Context, vpc *digitalocean.Vpc, cluster *Cluster) (*digitalocean.KubernetesCluster, error) {

--- a/internal/gh/gh_test.go
+++ b/internal/gh/gh_test.go
@@ -29,7 +29,9 @@ func TestCreateRepository(t *testing.T) {
 
 func TestCreateRepositoryRequiresChecks(t *testing.T) {
 	repository := &gh.Repository{
-		Name: "test", Description: "test", HomepageURL: "https://alexfalkowski.github.io/test",
+		Name:        "test",
+		Description: "test",
+		HomepageURL: "https://alexfalkowski.github.io/test",
 	}
 
 	require.Error(t, createRepository(t, repository, &test.Stub{}))
@@ -37,9 +39,11 @@ func TestCreateRepositoryRequiresChecks(t *testing.T) {
 
 func TestCreateRepositoryRequiresCompleteTemplate(t *testing.T) {
 	repository := &gh.Repository{
-		Name: "test", Description: "test", HomepageURL: "https://alexfalkowski.github.io/test",
-		Template: &gh.Template{Owner: "alexfalkowski"},
-		Checks:   gh.Checks{"ci/circleci: build"},
+		Name:        "test",
+		Description: "test",
+		HomepageURL: "https://alexfalkowski.github.io/test",
+		Template:    &gh.Template{Owner: "alexfalkowski"},
+		Checks:      gh.Checks{"ci/circleci: build"},
 	}
 
 	require.Error(t, createRepository(t, repository, &test.Stub{}))
@@ -90,7 +94,7 @@ func TestCreateRepositoryReturnsCollaboratorError(t *testing.T) {
 
 func TestCreateRepositoryFromIncompleteTemplateConfig(t *testing.T) {
 	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
-		a := gh.ConvertRepository(&v2.Repository{
+		repository := gh.ConvertRepository(&v2.Repository{
 			Name:        "test",
 			Description: "test",
 			HomepageUrl: "https://alexfalkowski.github.io/test",
@@ -98,8 +102,8 @@ func TestCreateRepositoryFromIncompleteTemplateConfig(t *testing.T) {
 			Checks:      []string{"ci/circleci: build"},
 		})
 
-		require.NotNil(t, a.Template)
-		err := gh.CreateRepository(ctx, a)
+		require.NotNil(t, repository.Template)
+		err := gh.CreateRepository(ctx, repository)
 		require.ErrorIs(t, err, gh.ErrMissingTemplate)
 
 		return nil

--- a/internal/gh/repository.go
+++ b/internal/gh/repository.go
@@ -12,7 +12,7 @@ import (
 // repository template and GitHub Pages configuration. Secret scanning, push protection, and
 // vulnerability alerts are enabled for every repository.
 func repository(ctx *pulumi.Context, repo *Repository) (*github.Repository, error) {
-	t, err := template(repo)
+	templateArgs, err := template(repo)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +46,7 @@ func repository(ctx *pulumi.Context, repo *Repository) (*github.Repository, erro
 			},
 		},
 		SquashMergeCommitTitle:   pulumi.String("PR_TITLE"),
-		Template:                 t,
+		Template:                 templateArgs,
 		Topics:                   pulumi.ToStringArray(repo.Topics),
 		Visibility:               pulumi.String(repo.Visibility),
 		WebCommitSignoffRequired: inputs.No,

--- a/internal/test/stub.go
+++ b/internal/test/stub.go
@@ -71,14 +71,14 @@ func (s *ResourceStub) FailResourceWith(token string, err error) {
 	s.failResource(token, 0, err)
 }
 
-// FailResourceAt makes the occurrence-th resource creation for token fail with ErrResource.
+// FailResourceAt makes the specified occurrence of resource creation for token fail with ErrResource.
 //
 // Occurrence is one-based.
 func (s *ResourceStub) FailResourceAt(token string, occurrence int) {
 	s.FailResourceAtWith(token, occurrence, ErrResource)
 }
 
-// FailResourceAtWith makes the occurrence-th resource creation for token fail with err.
+// FailResourceAtWith makes the specified occurrence of resource creation for token fail with err.
 //
 // Occurrence is one-based.
 func (s *ResourceStub) FailResourceAtWith(token string, occurrence int, err error) {
@@ -152,9 +152,9 @@ func Property(t *testing.T, properties resource.PropertyMap, key string) resourc
 
 // StringValues converts Pulumi property values to strings.
 func StringValues(values []resource.PropertyValue) []string {
-	strings := make([]string, 0, len(values))
+	result := make([]string, 0, len(values))
 	for _, value := range values {
-		strings = append(strings, value.StringValue())
+		result = append(result, value.StringValue())
 	}
-	return strings
+	return result
 }


### PR DESCRIPTION
## What

- Apply non-blocking readability polish across app, provider, helper, Makefile, config, and documentation files.
- Clarify local variable names, test helper names, comments, CLI help text, and small fixture formatting.
- Regenerate protobuf Go comments from the polished schema wording.

## Why

- Make the repository easier to scan and maintain without changing runtime behavior.

## Testing

- `make dep` - passed
- `make api-generate` - passed
- `make api-lint` - passed
- `make api-breaking` - passed
- `make build-bump` - passed
- `make build-format` - passed
- `make lint` - passed
- `make specs` - passed
- `git diff --check` - passed
