### PR TITLE
feat(k8s): harden workload security posture

### DIFF
--- a/area/k8s/Makefile
+++ b/area/k8s/Makefile
@@ -18,7 +18,7 @@ setup-helm:
 
 # Install CircleCI. This target is run manually from an operator workstation, not CI.
 install-circleci:
-	@helm upgrade --install circleci-release circleci/circleci-release-agent --set tokenSecret.token=$(CIRCLECI_K8S_TOKEN) --create-namespace --namespace circleci --set managedNamespaces="{lean}" --version 1.6.2
+	@helm upgrade --install circleci-release circleci/circleci-release-agent --set tokenSecret.token=$(CIRCLECI_K8S_TOKEN) --create-namespace --namespace circleci --set managedNamespaces="{lean}" --set rbac.clusterRoles=false --version 1.6.2
 
 # Install metrics server.
 install-metrics-server:

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -130,6 +130,7 @@ func TestConvertedApplicationDeploymentInputs(t *testing.T) {
 	require.Equal(t, "128Mi", resourceLimit(deployment, "memory"))
 	require.Equal(t, "1Gi", resourceRequest(deployment, "ephemeral-storage"))
 	require.Equal(t, "2Gi", resourceLimit(deployment, "ephemeral-storage"))
+	require.Equal(t, "RuntimeDefault", seccompProfileType(deployment))
 
 	secret := envVar(deployment, "DATABASE_PASSWORD")
 	valueFrom := test.Property(t, secret, "valueFrom").ObjectValue()
@@ -283,6 +284,12 @@ func resourceValue(deployment resource.PropertyMap, kind, name string) string {
 	resources := container(deployment)[resource.PropertyKey("resources")].ObjectValue()
 	values := resources[resource.PropertyKey(kind)].ObjectValue()
 	return values[resource.PropertyKey(name)].StringValue()
+}
+
+func seccompProfileType(deployment resource.PropertyMap) string {
+	security := container(deployment)[resource.PropertyKey("securityContext")].ObjectValue()
+	profile := security[resource.PropertyKey("seccompProfile")].ObjectValue()
+	return profile[resource.PropertyKey("type")].StringValue()
 }
 
 func deploymentSpec(deployment resource.PropertyMap) resource.PropertyMap {

--- a/internal/app/container.go
+++ b/internal/app/container.go
@@ -39,10 +39,7 @@ func internalContainer(app *App) cv1.ContainerArray {
 		ReadinessProbe:  httpProbe(probePath(app.Name, "readyz")),
 		StartupProbe:    tcpProbe(),
 		Resources:       createResources(app),
-		SecurityContext: cv1.SecurityContextArgs{
-			ReadOnlyRootFilesystem:   inputs.Yes,
-			AllowPrivilegeEscalation: inputs.No,
-		},
+		SecurityContext: containerSecurity(),
 	}
 	return cv1.ContainerArray{container}
 }
@@ -58,12 +55,19 @@ func externalContainer(app *App) cv1.ContainerArray {
 		ReadinessProbe:  tcpProbe(),
 		StartupProbe:    tcpProbe(),
 		Resources:       createResources(app),
-		SecurityContext: cv1.SecurityContextArgs{
-			ReadOnlyRootFilesystem:   inputs.Yes,
-			AllowPrivilegeEscalation: inputs.No,
-		},
+		SecurityContext: containerSecurity(),
 	}
 	return cv1.ContainerArray{container}
+}
+
+func containerSecurity() cv1.SecurityContextArgs {
+	return cv1.SecurityContextArgs{
+		ReadOnlyRootFilesystem:   inputs.Yes,
+		AllowPrivilegeEscalation: inputs.No,
+		SeccompProfile: cv1.SeccompProfileArgs{
+			Type: pulumi.String("RuntimeDefault"),
+		},
+	}
 }
 
 func serviceID() cv1.EnvVarArgs {


### PR DESCRIPTION
## What

- Scope the CircleCI release agent RBAC to the managed lean namespace instead of creating cluster-wide roles.
- Add RuntimeDefault seccomp profiles to generated app containers while preserving the existing read-only root filesystem and no privilege escalation settings.
- Cover the generated deployment seccomp profile in app resource tests.

## Why

- Reduces blast radius from the Kubescape RBAC findings for the CircleCI release agent without changing the app deployment workflow.
- Clears the app-owned Kubescape Linux hardening findings for lean workloads and leaves provider/system add-on findings as separate follow-up scope.

## Testing

- `make dep` - passed
- `go test ./internal/app` - passed
- `make specs` - passed
- `make lint` - passed
- `make sec` - passed
- `kubescape scan control C-0055 -v` - passed; verified lean app deployments no longer appear in Linux hardening findings, with remaining findings limited to provider/system/add-on workloads
- `kubectl get deployment bezeichner standort web --namespace lean -o yaml` - passed; verified live app containers use `seccompProfile.type: RuntimeDefault`
