### PR TITLE
feat(release): halt app version-only changes on every branch

### DIFF
--- a/area/apps/release
+++ b/area/apps/release
@@ -209,12 +209,8 @@ load_release_changes() {
   done
 }
 
-# Halts CircleCI for master release-only app changes.
+# Halts CircleCI for release-only app changes.
 halt_ci() {
-  if [[ "${CIRCLE_BRANCH:-}" != "master" ]]; then
-    return
-  fi
-
   if ! release_apps >/dev/null; then
     return
   fi


### PR DESCRIPTION
## What

- Allow the app release halt step to run on both branch builds and `master`.
- Keep the release-only app version diff check as the guard before halting CircleCI.

## Why

- Release-only app version PRs should skip the expensive build job before merge, not only after landing on `master`.
- The previous branch check prevented PR branches from halting even when the diff was exactly an app version change.

## Testing

- `make dep` - passed
- `shellcheck area/apps/release` - passed
- `bash -n area/apps/release` - passed
- `APPS_RELEASE_DRY_RUN=true CIRCLE_BRANCH=alejandro-71689/release/standort APPS_RELEASE_BASE=ed46ae5f^ APPS_RELEASE_HEAD=ed46ae5f ./area/apps/release halt-ci` - passed
- `APPS_RELEASE_DRY_RUN=true CIRCLE_BRANCH=master APPS_RELEASE_BASE=ed46ae5f^ APPS_RELEASE_HEAD=ed46ae5f ./area/apps/release halt-ci` - passed
- `APPS_RELEASE_DRY_RUN=true APPS_RELEASE_BASE=HEAD APPS_RELEASE_HEAD=HEAD ./area/apps/release halt-ci` - passed
- `APPS_RELEASE_DRY_RUN=true APPS_RELEASE_BASE=ed46ae5f^ APPS_RELEASE_HEAD=ed46ae5f make -C area/apps load` - passed
