### PR TITLE
feat(release): target app operations by changed version

### DIFF
--- a/area/apps/Makefile
+++ b/area/apps/Makefile
@@ -20,10 +20,20 @@ setup: setup-lean
 delete: delete-lean
 
 # Rollout all apps.
-rollout: rollout-lean
+rollout-all:
+	@./release rollout-all
+
+# Rollout release app changes.
+rollout:
+	@./release rollout
 
 # Verify all apps.
-verify: verify-lean
+verify-all:
+	@./release verify-all
+
+# Verify release app changes.
+verify:
+	@./release verify
 
 # Load all apps.
 load-all:

--- a/area/apps/lean.mk
+++ b/area/apps/lean.mk
@@ -18,33 +18,3 @@ create-lean:
 
 # Setup lean.
 setup-lean: create-lean
-
-# Rollout lean.
-rollout-lean: rollout-standort rollout-bezeichner rollout-web
-
-# Rollout standort.
-rollout-standort:
-	@kubectl rollout restart deployment/standort -n lean
-
-# Rollout bezeichner.
-rollout-bezeichner:
-	@kubectl rollout restart deployment/bezeichner -n lean
-
-# Rollout web.
-rollout-web:
-	@kubectl rollout restart deployment/web -n lean
-
-# Verify all apps.
-verify-lean: verify-standort verify-bezeichner verify-web
-
-# Verify standort.
-verify-standort:
-	@curl -svf --header "Content-Type: application/json" --request POST --data {} https://standort.lean-thoughts.com/standort.v2.Service/GetLocation
-
-# Verify bezeichner.
-verify-bezeichner:
-	@curl -svf --header "Content-Type: application/json" --request POST --data '{ "application": "ulid", "count": 10 }' https://bezeichner.lean-thoughts.com/bezeichner.v1.Service/GenerateIdentifiers
-
-# Verify web.
-verify-web:
-	@curl -svf https://web.lean-thoughts.com

--- a/area/apps/main_test.go
+++ b/area/apps/main_test.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
-	"github.com/alexfalkowski/infraops/v2/internal/app"
 	"github.com/alexfalkowski/infraops/v2/internal/test"
 	"github.com/stretchr/testify/require"
 )
@@ -23,26 +20,6 @@ func TestCreate(t *testing.T) {
 	}
 }
 
-func TestLeanMakefileCoversConfiguredApps(t *testing.T) {
-	config, err := app.ReadConfiguration("apps.hjson")
-	require.NoError(t, err)
-
-	content, err := os.ReadFile("lean.mk")
-	require.NoError(t, err)
-
-	targets := makefileTargets(string(content))
-	for _, workflow := range []string{"rollout", "verify"} {
-		aggregate := workflow + "-lean"
-		require.Contains(t, targets, aggregate)
-
-		for _, application := range config.GetApplications() {
-			target := workflow + "-" + application.GetName()
-			require.Contains(t, targets[aggregate], target)
-			require.Contains(t, targets, target)
-		}
-	}
-}
-
 type fixture struct {
 	name string
 	path string
@@ -53,23 +30,4 @@ func fixtures() []fixture {
 		{name: "area", path: "apps.hjson"},
 		{name: "shared", path: filepath.Join("..", "..", "internal", "test", "apps.hjson")},
 	}
-}
-
-func makefileTargets(content string) map[string][]string {
-	targets := map[string][]string{}
-	for line := range strings.SplitSeq(content, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "@") {
-			continue
-		}
-
-		target, dependencies, ok := strings.Cut(line, ":")
-		if !ok {
-			continue
-		}
-
-		targets[strings.TrimSpace(target)] = strings.Fields(dependencies)
-	}
-
-	return targets
 }

--- a/area/apps/release
+++ b/area/apps/release
@@ -9,10 +9,11 @@ readonly APP_MAKE_DIR="area/apps"
 readonly LOAD_DURATION="30s"
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+readonly -a APPS=(standort bezeichner web)
 
 # Prints command usage.
 usage() {
-  printf 'Usage: %s <halt-ci|is-release|load|load-all|load-bezeichner|load-standort|load-web>\n' "$0" >&2
+  printf 'Usage: %s <halt-ci|is-release|load|load-all|load-bezeichner|load-standort|load-web|rollout|rollout-all|rollout-bezeichner|rollout-standort|rollout-web|verify|verify-all|verify-bezeichner|verify-standort|verify-web>\n' "$0" >&2
 }
 
 # Prints the revision to inspect for app release changes.
@@ -121,38 +122,106 @@ release_apps() {
   printf '%s\n' "${apps[@]}"
 }
 
-# Runs an app load target, or prints it when dry-run mode is enabled.
-load_app() {
-  local app
-
-  app="$1"
-  if [[ "${APPS_RELEASE_DRY_RUN:-}" == "true" ]]; then
-    printf './%s/release load-%s\n' "$APP_MAKE_DIR" "$app"
-    return
-  fi
-
-  case "$app" in
-    bezeichner)
-      load_bezeichner
-      ;;
-    standort)
-      load_standort
-      ;;
-    web)
-      load_web
+# Reports whether an app has release helper commands.
+is_app() {
+  case "$1" in
+    bezeichner | standort | web)
+      return 0
       ;;
     *)
-      printf 'invalid app name: %s\n' "$app" >&2
       return 1
       ;;
   esac
 }
 
+# Reports whether an app action has release helper commands.
+is_action() {
+  case "$1" in
+    load | rollout | verify)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# Runs an app action, or prints it when dry-run mode is enabled.
+run_app_action() {
+  local action
+  local app
+
+  action="$1"
+  app="$2"
+
+  if ! is_action "$action"; then
+    printf 'invalid action: %s\n' "$action" >&2
+    return 1
+  fi
+
+  if ! is_app "$app"; then
+    printf 'invalid app name: %s\n' "$app" >&2
+    return 1
+  fi
+
+  if [[ "${APPS_RELEASE_DRY_RUN:-}" == "true" ]]; then
+    printf './%s/release %s-%s\n' "$APP_MAKE_DIR" "$action" "$app"
+    return
+  fi
+
+  "${action}_${app}"
+}
+
+# Runs an app action for every supported app.
+run_all_apps() {
+  local action
+  local app
+
+  action="$1"
+  if ! is_action "$action"; then
+    printf 'invalid action: %s\n' "$action" >&2
+    return 1
+  fi
+
+  for app in "${APPS[@]}"; do
+    run_app_action "$action" "$app"
+  done
+}
+
+# Runs a release-aware app action and falls back to all apps.
+run_release_changes() {
+  local action
+  local app
+  local apps=()
+  local label
+
+  action="$1"
+  label="$2"
+
+  while IFS= read -r app; do
+    [[ -n "$app" ]] && apps+=("$app")
+  done < <(release_apps || true)
+
+  if ((${#apps[@]} == 0)); then
+    printf '%s all apps.\n' "$label"
+    run_all_apps "$action"
+    return
+  fi
+
+  for app in "${apps[@]}"; do
+    if ! is_app "$app"; then
+      printf 'invalid app name: %s\n' "$app" >&2
+      return 1
+    fi
+
+    printf '%s release app: %s\n' "$label" "$app"
+    run_app_action "$action" "$app"
+  done
+}
+
 # Load tests all apps.
 load_all() {
-  load_app "standort"
-  load_app "bezeichner"
-  load_app "web"
+  run_all_apps "load"
 }
 
 # Load tests standort.
@@ -185,28 +254,65 @@ load_web() {
 
 # Loads targeted release apps and falls back to the full apps load target.
 load_release_changes() {
-  local app
-  local apps=()
+  run_release_changes "load" "Loading"
+}
 
-  while IFS= read -r app; do
-    [[ -n "$app" ]] && apps+=("$app")
-  done < <(release_apps || true)
+# Rolls out all apps.
+rollout_all() {
+  run_all_apps "rollout"
+}
 
-  if ((${#apps[@]} == 0)); then
-    printf 'Loading all apps.\n'
-    load_all
-    return
-  fi
+# Rolls out standort.
+rollout_standort() {
+  kubectl rollout restart deployment/standort -n lean
+}
 
-  for app in "${apps[@]}"; do
-    if [[ ! "$app" =~ ^[a-z0-9-]+$ ]]; then
-      printf 'invalid app name: %s\n' "$app" >&2
-      return 1
-    fi
+# Rolls out bezeichner.
+rollout_bezeichner() {
+  kubectl rollout restart deployment/bezeichner -n lean
+}
 
-    printf 'Loading release app: %s\n' "$app"
-    load_app "$app"
-  done
+# Rolls out web.
+rollout_web() {
+  kubectl rollout restart deployment/web -n lean
+}
+
+# Rolls out targeted release apps and falls back to the full apps rollout target.
+rollout_release_changes() {
+  run_release_changes "rollout" "Rolling out"
+}
+
+# Verifies all apps.
+verify_all() {
+  run_all_apps "verify"
+}
+
+# Verifies standort.
+verify_standort() {
+  curl -svf \
+    --header "Content-Type: application/json" \
+    --request POST \
+    --data "{}" \
+    https://standort.lean-thoughts.com/standort.v2.Service/GetLocation
+}
+
+# Verifies bezeichner.
+verify_bezeichner() {
+  curl -svf \
+    --header "Content-Type: application/json" \
+    --request POST \
+    --data '{ "application": "ulid", "count": 10 }' \
+    https://bezeichner.lean-thoughts.com/bezeichner.v1.Service/GenerateIdentifiers
+}
+
+# Verifies web.
+verify_web() {
+  curl -svf https://web.lean-thoughts.com
+}
+
+# Verifies targeted release apps and falls back to the full apps verify target.
+verify_release_changes() {
+  run_release_changes "verify" "Verifying"
 }
 
 # Halts CircleCI for release-only app changes.
@@ -237,13 +343,43 @@ case "${1:-}" in
     load_all
     ;;
   load-bezeichner)
-    load_app "bezeichner"
+    run_app_action "load" "bezeichner"
     ;;
   load-standort)
-    load_app "standort"
+    run_app_action "load" "standort"
     ;;
   load-web)
-    load_app "web"
+    run_app_action "load" "web"
+    ;;
+  rollout)
+    rollout_release_changes
+    ;;
+  rollout-all)
+    rollout_all
+    ;;
+  rollout-bezeichner)
+    run_app_action "rollout" "bezeichner"
+    ;;
+  rollout-standort)
+    run_app_action "rollout" "standort"
+    ;;
+  rollout-web)
+    run_app_action "rollout" "web"
+    ;;
+  verify)
+    verify_release_changes
+    ;;
+  verify-all)
+    verify_all
+    ;;
+  verify-bezeichner)
+    run_app_action "verify" "bezeichner"
+    ;;
+  verify-standort)
+    run_app_action "verify" "standort"
+    ;;
+  verify-web)
+    run_app_action "verify" "web"
     ;;
   *)
     usage


### PR DESCRIPTION
## What

- Route app rollout and verification through the same release-aware script path as load testing.
- Add explicit `rollout-all` and `verify-all` Make targets for full-app operator runs.
- Keep concrete app commands in `area/apps/release` while sharing app/action dispatch and dry-run handling.
- Remove the old `lean.mk` per-app rollout and verification targets, along with their obsolete Makefile coverage test.

## Why

- Release-only app version updates should operate on the changed app consistently across rollout, verification, and load testing.
- Keeping the app operation commands in one script avoids split behavior between Make fragments and CI/operator paths.

## Testing

- `make dep` - passed
- `shellcheck area/apps/release` - passed
- `bash -n area/apps/release` - passed
- `go test ./area/apps` - passed
- `make lint` - passed
- `APPS_RELEASE_DRY_RUN=true APPS_RELEASE_BASE=554315de^ APPS_RELEASE_HEAD=554315de make -C area/apps rollout` - passed
- `APPS_RELEASE_DRY_RUN=true APPS_RELEASE_BASE=554315de^ APPS_RELEASE_HEAD=554315de make -C area/apps verify` - passed
- `APPS_RELEASE_DRY_RUN=true APPS_RELEASE_BASE=554315de^ APPS_RELEASE_HEAD=554315de make -C area/apps load` - passed
- `APPS_RELEASE_DRY_RUN=true make -C area/apps rollout-all` - passed
- `APPS_RELEASE_DRY_RUN=true make -C area/apps verify-all` - passed
- `APPS_RELEASE_DRY_RUN=true make -C area/apps load-all` - passed
- `APPS_RELEASE_DRY_RUN=true APPS_RELEASE_BASE=HEAD APPS_RELEASE_HEAD=HEAD make -C area/apps rollout` - passed
- `APPS_RELEASE_DRY_RUN=true APPS_RELEASE_BASE=HEAD APPS_RELEASE_HEAD=HEAD make -C area/apps verify` - passed
