### PR TITLE
docs(readme): clarify infra operator guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Operator-only helper targets use these tools as needed:
 
 - `make -C area/apps save-config` and `make -C area/k8s save-config`: `doctl`
 - `make -C area/apps setup|delete|rollout`: `kubectl`
-- `make -C area/apps lint`: `kube-score`, `kubescape`, `kubectl`
+- `make -C area/apps lint`: `kube-score`, `kubescape`, `kubectl` (live `lean` namespace scan)
 - `make -C area/apps verify`: `curl`
 - `make -C area/apps load`: `vegeta`
 - `make -C area/k8s setup|delete|pods`: `helm`, `kubectl`
@@ -290,6 +290,38 @@ Apply the Pulumi resources described by `apps.hjson`:
 make area=apps pulumi-update
 ```
 
+#### 🧪 App Helpers
+
+The default `rollout`, `verify`, and `load` helper targets are release-aware. They inspect the app
+release diff and target only apps with version-only changes in `area/apps/apps.hjson`; when the diff
+is not a release-only app change, they fall back to all supported apps.
+
+```bash
+make -C area/apps rollout
+make -C area/apps verify
+make -C area/apps load
+```
+
+Use the `*-all` targets when you want to cover every supported app explicitly:
+
+```bash
+make -C area/apps rollout-all
+make -C area/apps verify-all
+make -C area/apps load-all
+```
+
+Per-app commands are exposed by the release helper:
+
+```bash
+cd area/apps
+./release verify-web
+./release load-bezeichner
+./release rollout-standort
+```
+
+The `lint` target reads live resources from the `lean` namespace and scans them with kube-score and
+kubescape; it requires a working cluster context.
+
 #### 🗑️ Delete
 
 > [!CAUTION]
@@ -470,6 +502,11 @@ Setup:
 ```bash
 make -C area/k8s setup
 ```
+
+The nginx ingress add-on uses the Helm values in `area/k8s/nginx/values.yaml`. Those values restrict
+the DigitalOcean load balancer allow rules to Cloudflare CIDR ranges, so the ingress is intended for
+Cloudflare-proxied origin traffic. Direct clients or non-Cloudflare DNS paths may be blocked at the
+load balancer.
 
 Delete:
 

--- a/api/infraops/v2/service.pb.go
+++ b/api/infraops/v2/service.pb.go
@@ -109,7 +109,15 @@ type Application struct {
 	// It is available for callers/tools but may not be used by all provisioners.
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// Kind determines the deployment model for this application.
-	// The Go implementation recognizes values like "internal" and "external".
+	//
+	// Supported values:
+	//   - "internal": use the repository-built image tag format, mount the application config file
+	//     and listed secret volumes, inject SERVICE_ID, and expose debug/http/grpc ports.
+	//   - "external": use the external image tag format, skip app config and secret volume mounts,
+	//     and expose only the HTTP port.
+	//
+	// Other values are unsupported. The current implementation does not pre-validate this field, so
+	// unsupported values can produce mixed resource behavior during Pulumi preview/update.
 	Kind string `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
 	// Name is the Kubernetes resource name base for this application.
 	Name string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
@@ -405,6 +413,8 @@ func (x *Template) GetRepository() string {
 }
 
 // Pages describes GitHub Pages configuration for a repository.
+//
+// When enabled, the implementation creates legacy GitHub Pages configuration sourced from "master".
 type Pages struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Enabled controls whether Pages should be enabled/managed.
@@ -463,6 +473,11 @@ func (x *Pages) GetCname() string {
 //
 // This configuration is consumed by the `area/gh` Pulumi program, which creates the repository
 // and applies additional settings such as branch protection, Pages, and collaborators.
+//
+// Every repository also receives the fixed repository baseline in the Go implementation: merge and
+// rebase commits disabled, squash merge/automerge/update branch/delete branch enabled, auto-init
+// enabled, issues/projects/wiki enabled, secret scanning and push protection enabled, vulnerability
+// alerts enabled, and web commit signoff disabled. These settings are not configurable in HJSON.
 type Repository struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Name is the repository name.

--- a/api/infraops/v2/service.proto
+++ b/api/infraops/v2/service.proto
@@ -45,7 +45,15 @@ message Application {
   string id = 1;
 
   // Kind determines the deployment model for this application.
-  // The Go implementation recognizes values like "internal" and "external".
+  //
+  // Supported values:
+  //   - "internal": use the repository-built image tag format, mount the application config file
+  //     and listed secret volumes, inject SERVICE_ID, and expose debug/http/grpc ports.
+  //   - "external": use the external image tag format, skip app config and secret volume mounts,
+  //     and expose only the HTTP port.
+  //
+  // Other values are unsupported. The current implementation does not pre-validate this field, so
+  // unsupported values can produce mixed resource behavior during Pulumi preview/update.
   string kind = 2;
 
   // Name is the Kubernetes resource name base for this application.
@@ -121,6 +129,8 @@ message Template {
 }
 
 // Pages describes GitHub Pages configuration for a repository.
+//
+// When enabled, the implementation creates legacy GitHub Pages configuration sourced from "master".
 message Pages {
   // Enabled controls whether Pages should be enabled/managed.
   bool enabled = 1;
@@ -133,6 +143,11 @@ message Pages {
 //
 // This configuration is consumed by the `area/gh` Pulumi program, which creates the repository
 // and applies additional settings such as branch protection, Pages, and collaborators.
+//
+// Every repository also receives the fixed repository baseline in the Go implementation: merge and
+// rebase commits disabled, squash merge/automerge/update branch/delete branch enabled, auto-init
+// enabled, issues/projects/wiki enabled, secret scanning and push protection enabled, vulnerability
+// alerts enabled, and web commit signoff disabled. These settings are not configurable in HJSON.
 message Repository {
   // Name is the repository name.
   string name = 1;

--- a/area/apps/Makefile
+++ b/area/apps/Makefile
@@ -6,7 +6,7 @@ kube-score: kube-score-lean
 # Run kubescape.
 kubescape: kubescape-lean
 
-# Lint config.
+# Lint live app resources.
 lint: kube-score kubescape
 
 # Save kubeconfig.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -98,7 +98,7 @@ type App struct {
 	Kind string
 	// Namespace is the Kubernetes namespace to deploy into.
 	Namespace string
-	// Domain is the external hostname associated with the application.
+	// Domain is the base/apex domain suffix used to build the ingress host <name>.<domain>.
 	Domain string
 	// Version is the application version string used for deployment (for example as an image tag).
 	Version string


### PR DESCRIPTION
## What

- Clarifies the application kind contract in the protobuf schema, including supported values and their deployment effects.
- Documents the fixed GitHub repository baseline and Pages source behavior in the config schema.
- Adds operator guidance for release-aware app helpers, live app resource linting, and Cloudflare-only nginx ingress load balancer access.
- Corrects the `App.Domain` GoDoc to describe the base/apex domain suffix used for ingress host construction.

## Why

- Reduces operator and maintainer confusion around configuration fields and helper targets whose behavior is broader than their previous comments described.
- Makes non-configurable infrastructure defaults visible where users edit schema-backed HJSON and run local Kubernetes workflows.

## Testing

- `make dep` - passed
- `make api-generate` - passed
- `make api-lint` - passed
- `make lint` - passed
- `git diff --check` - passed
