### PR TITLE
docs(readme): clarify infrastructure configuration behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,16 @@ Override the path:
 
 A few conventions are implemented by the Go code and are worth knowing when editing HJSON:
 
+#### 🧭 `Application.kind` Deployment Model (apps)
+
+Supported values:
+
+- `"internal"`: uses image tag `docker.io/alexfalkowski/<name>:v<version>`, mounts the app config file and listed secret volumes, injects `SERVICE_ID`, runs the container with `server`, and exposes debug `6060`, HTTP `8080`, and gRPC `9090`.
+- `"external"`: uses image tag `docker.io/alexfalkowski/<name>:<version>`, skips app config and secret volume mounts, and exposes only HTTP `8080`.
+
+Other values are unsupported and are not pre-validated by the helper code; malformed values may fail
+later during Pulumi/Kubernetes application.
+
 #### 🔐 `EnvVar.value` Secret References (apps)
 
 Environment variables support literal values, and a secret reference format:
@@ -436,6 +446,14 @@ Config:
 This area was inspired by:
 
 - <https://github.com/dirien/pulumi-github>
+
+#### 🛡️ Branch Protection Baseline
+
+Every repository must list at least one `checks` entry. Those values become the required status
+check contexts for strict branch protection on `master`; an empty list fails during provisioning.
+
+Branch protection also enforces linear history and intentionally requires zero approving PR reviews
+because required status checks are the primary merge gate for this solo-maintainer workflow.
 
 #### 🪜 Repository Creation Caveat (2-step enablement)
 

--- a/api/infraops/v2/service.pb.go
+++ b/api/infraops/v2/service.pb.go
@@ -959,7 +959,7 @@ type Cloudflare struct {
 	Version string `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
 	// BalancerZones is the set of zones for which proxied A/AAAA records are managed.
 	BalancerZones []*BalancerZone `protobuf:"bytes,2,rep,name=balancer_zones,json=balancerZones,proto3" json:"balancer_zones,omitempty"`
-	// PageZones is the set of zones configured for Cloudflare Pages sites.
+	// PageZones is the set of zones configured for static-site or pages-style CNAME targets.
 	PageZones []*PageZone `protobuf:"bytes,3,rep,name=page_zones,json=pageZones,proto3" json:"page_zones,omitempty"`
 	// Buckets is the set of R2 buckets to create/manage, optionally with custom domains.
 	Buckets       []*Bucket `protobuf:"bytes,4,rep,name=buckets,proto3" json:"buckets,omitempty"`

--- a/api/infraops/v2/service.proto
+++ b/api/infraops/v2/service.proto
@@ -270,7 +270,7 @@ message Cloudflare {
   // BalancerZones is the set of zones for which proxied A/AAAA records are managed.
   repeated BalancerZone balancer_zones = 2;
 
-  // PageZones is the set of zones configured for Cloudflare Pages sites.
+  // PageZones is the set of zones configured for static-site or pages-style CNAME targets.
   repeated PageZone page_zones = 3;
 
   // Buckets is the set of R2 buckets to create/manage, optionally with custom domains.


### PR DESCRIPTION
## What

- Document the supported apps deployment models so operators can see how internal and external applications differ before editing HJSON.
- Document the GitHub required checks and branch protection baseline applied by the repository area.
- Clarify that Cloudflare page zones cover static-site or pages-style CNAME targets, then regenerate the protobuf Go comments.

## Why

- These notes close confirmed documentation gaps where behavior was only visible in implementation or schema comments.
- The added guidance reduces failed Pulumi/Kubernetes or GitHub provisioning attempts caused by omitted required checks, unsupported app kinds, or overly narrow Cloudflare terminology.

## Testing

- `make api-generate` - passed
- `make api-lint` - passed
- `make api-breaking` - passed
- `make lint` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
