### PR TITLE
docs(readme): clarify infrastructure configuration contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,17 @@ Supported values:
 Other values are unsupported and are not pre-validated by the helper code; malformed values may fail
 later during Pulumi/Kubernetes application.
 
+Internal apps also receive CircleCI release-agent labels/annotations and must serve HTTP
+liveness/readiness probes at `/<name>/livez` and `/<name>/readyz` on port `8080`; startup uses a TCP
+probe on `8080`. External apps skip CircleCI release-agent labels/annotations and use `/` for HTTP
+liveness plus TCP readiness/startup probes on `8080`.
+
+#### 🪪 `Application.id` CircleCI Project ID (apps)
+
+For internal apps, `Application.id` is written to the deployment annotation
+`circleci.com/project-id`. Keep it aligned with the CircleCI project identifier when adding or
+renaming internal apps. External apps do not receive CircleCI release-agent labels or annotations.
+
 #### 🔐 `EnvVar.value` Secret References (apps)
 
 Environment variables support literal values, and a secret reference format:
@@ -205,6 +216,9 @@ make api-generate
 
 (Or: `make -C api lint|breaking|generate`.)
 
+`make api-breaking` compares the API module against the GitHub `master` branch, so it needs network
+access to run outside CI.
+
 ## 🚀 Pulumi: Preview/Update Per Area
 
 Pulumi is typically run via Makefile targets from the repo root.
@@ -253,7 +267,7 @@ make area=cf pulumi-delete
 ```
 
 > [!WARNING]
-> `pulumi-update`, `pulumi-refresh`, and `pulumi-cancel` affect remote infrastructure or stack state. Run a preview first unless you are recovering from a known failed operation.
+> `pulumi-update`, `pulumi-refresh`, and `pulumi-cancel` affect remote infrastructure or stack state. The Make targets pass `--yes`, so treat the preview as the confirmation step unless you are recovering from a known failed operation.
 
 > [!CAUTION]
 > `pulumi-delete` runs `pulumi stack rm --force`; it removes Pulumi stack state and can orphan managed resources if they still exist.
@@ -279,6 +293,10 @@ Internal apps also need an application config file at:
 For example, the `bezeichner` app in namespace `lean` reads `area/apps/lean/bezeichner.yaml`.
 The apps Pulumi program turns that file into a Kubernetes ConfigMap entry named `<app>.yaml`,
 then mounts it into the container at `/etc/<app>/<app>.yaml`.
+
+Only applications listed in `area/apps/apps.hjson` are deployed. The tracked files under
+`area/apps/fiction/` are example app configs and are not used unless a matching app entry references
+that namespace/name.
 
 #### 🏗️ Install / Setup
 
@@ -319,6 +337,8 @@ make -C area/apps rollout-all
 make -C area/apps verify-all
 make -C area/apps load-all
 ```
+
+The `load*` targets write ignored vegeta result files under `area/apps/lean/*.bin`.
 
 Per-app commands are exposed by the release helper:
 
@@ -374,6 +394,21 @@ Manages Cloudflare resources using Pulumi’s Cloudflare provider:
 Config:
 
 - `area/cf/cf.hjson`
+
+R2 buckets are optional. A bucket with a custom domain uses this shape:
+
+```hjson
+buckets: [
+  {
+    name: assets
+    region: EEUR
+    zone: {
+      id: "<cloudflare-zone-id>"
+      domain: assets.example.com
+    }
+  }
+]
+```
 
 #### 🔑 Required Environment Variables
 
@@ -481,6 +516,9 @@ pages: {
   cname: www.yoursite.com
 }
 ```
+
+Pages uses legacy GitHub Pages sourced from `master`; branch, path, and build type are not
+configurable in HJSON.
 
 ##### 👥 Collaborators
 

--- a/api/infraops/v2/service.pb.go
+++ b/api/infraops/v2/service.pb.go
@@ -105,16 +105,21 @@ func (x *EnvVar) GetValue() string {
 // resources such as ServiceAccount, ConfigMap, Deployment, Service, Ingress, and related policies.
 type Application struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Id is an optional identifier for the application in configuration.
-	// It is available for callers/tools but may not be used by all provisioners.
+	// Id is the CircleCI project identifier for internal application deployments.
+	// Internal deployments write this value to the "circleci.com/project-id" annotation used by the
+	// CircleCI release agent. External deployments do not receive CircleCI release-agent annotations.
+	// The implementation does not validate that the value is present or well-formed.
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// Kind determines the deployment model for this application.
 	//
 	// Supported values:
 	//   - "internal": use the repository-built image tag format, mount the application config file
-	//     and listed secret volumes, inject SERVICE_ID, and expose debug/http/grpc ports.
+	//     and listed secret volumes, inject SERVICE_ID, add CircleCI release-agent labels/annotations,
+	//     expose debug/http/grpc ports, and use HTTP liveness/readiness probes at
+	//     "/<name>/livez" and "/<name>/readyz" on port 8080 plus a TCP startup probe on 8080.
 	//   - "external": use the external image tag format, skip app config and secret volume mounts,
-	//     and expose only the HTTP port.
+	//     skip CircleCI release-agent labels/annotations, expose only the HTTP port, and use "/"
+	//     for HTTP liveness plus TCP readiness/startup probes on 8080.
 	//
 	// Other values are unsupported. The current implementation does not pre-validate this field, so
 	// unsupported values can produce mixed resource behavior during Pulumi preview/update.
@@ -1028,6 +1033,9 @@ func (x *Cloudflare) GetBuckets() []*Bucket {
 // Cluster describes a DigitalOcean Kubernetes cluster to provision.
 //
 // The `area/do` Pulumi program currently provisions a VPC and then a Kubernetes cluster attached to it.
+// The cluster uses fixed operational defaults in code: region fra1, two nodes, Kubernetes version
+// pinned by the implementation, maintenance window "any" day at 23:00, and
+// DestroyAllAssociatedResources enabled.
 type Cluster struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Name is the cluster name used for resource naming.

--- a/api/infraops/v2/service.proto
+++ b/api/infraops/v2/service.proto
@@ -40,17 +40,22 @@ message EnvVar {
 // This configuration is consumed by the `area/apps` Pulumi program, which creates Kubernetes
 // resources such as ServiceAccount, ConfigMap, Deployment, Service, Ingress, and related policies.
 message Application {
-  // Id is an optional identifier for the application in configuration.
-  // It is available for callers/tools but may not be used by all provisioners.
+  // Id is the CircleCI project identifier for internal application deployments.
+  // Internal deployments write this value to the "circleci.com/project-id" annotation used by the
+  // CircleCI release agent. External deployments do not receive CircleCI release-agent annotations.
+  // The implementation does not validate that the value is present or well-formed.
   string id = 1;
 
   // Kind determines the deployment model for this application.
   //
   // Supported values:
   //   - "internal": use the repository-built image tag format, mount the application config file
-  //     and listed secret volumes, inject SERVICE_ID, and expose debug/http/grpc ports.
+  //     and listed secret volumes, inject SERVICE_ID, add CircleCI release-agent labels/annotations,
+  //     expose debug/http/grpc ports, and use HTTP liveness/readiness probes at
+  //     "/<name>/livez" and "/<name>/readyz" on port 8080 plus a TCP startup probe on 8080.
   //   - "external": use the external image tag format, skip app config and secret volume mounts,
-  //     and expose only the HTTP port.
+  //     skip CircleCI release-agent labels/annotations, expose only the HTTP port, and use "/"
+  //     for HTTP liveness plus TCP readiness/startup probes on 8080.
   //
   // Other values are unsupported. The current implementation does not pre-validate this field, so
   // unsupported values can produce mixed resource behavior during Pulumi preview/update.
@@ -280,6 +285,9 @@ message Cloudflare {
 // Cluster describes a DigitalOcean Kubernetes cluster to provision.
 //
 // The `area/do` Pulumi program currently provisions a VPC and then a Kubernetes cluster attached to it.
+// The cluster uses fixed operational defaults in code: region fra1, two nodes, Kubernetes version
+// pinned by the implementation, maintenance window "any" day at 23:00, and
+// DestroyAllAssociatedResources enabled.
 message Cluster {
   // Name is the cluster name used for resource naming.
   string name = 1;

--- a/cmd/format/format.go
+++ b/cmd/format/format.go
@@ -30,8 +30,8 @@ func run() error {
 	)
 
 	set := flag.NewFlagSet("format", flag.ContinueOnError)
-	set.StringVar(&kind, "k", "", "config kind")
-	set.StringVar(&path, "p", "", "config file path")
+	set.StringVar(&kind, "k", "", "config kind (apps|cf|do|gh)")
+	set.StringVar(&path, "p", "", "config file path (default area/<kind>/<kind>.hjson)")
 	if err := set.Parse(os.Args[1:]); err != nil {
 		return err
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -94,7 +94,10 @@ type App struct {
 	ID string
 	// Name is the Kubernetes application name (used for resource naming).
 	Name string
-	// Kind determines how the application is deployed (for example "internal" vs "external").
+	// Kind determines how the application is deployed.
+	//
+	// Supported values are "internal" and "external". Unsupported values are not prevalidated
+	// and can produce mixed resource behavior during Pulumi preview/update.
 	Kind string
 	// Namespace is the Kubernetes namespace to deploy into.
 	Namespace string
@@ -141,7 +144,11 @@ type Range struct {
 
 // EnvVar represents an environment variable to inject into the application container.
 type EnvVar struct {
-	Name  string
+	Name string
+	// Value is either a literal value or a secret reference in the form
+	// "secret:<secretName>/<key>". Secret references become Kubernetes SecretKeyRefs
+	// with Secret name "<secretName>-secret" and key "<key>"; the shape is not
+	// prevalidated before Pulumi/Kubernetes application.
 	Value string
 }
 


### PR DESCRIPTION
## What

- Clarify non-obvious infrastructure configuration and operation contracts in the root documentation.
- Document internal app CircleCI annotations, health probe expectations, generated API comments, R2 bucket configuration shape, Pages source limits, and release helper side effects.
- Regenerate protobuf Go output after updating schema comments, and improve the config formatter flag help.

## Why

- Operators and service authors need these contracts before changing HJSON, running non-interactive Pulumi targets, or adding app/repository/cloud resources.
- Keeping the README, schema comments, Go API comments, and command help aligned reduces reliance on private implementation details for routine infrastructure changes.

## Testing

- `make dep` - passed
- `make api-generate` - passed
- `make api-lint` - passed
- `make build-format` - passed
- `make lint` - passed
- `make specs` - passed
- `make api-breaking` - passed
- `git diff --check` - passed
