### PR TITLE
build(project): lint operator workflow helpers

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -77,6 +77,7 @@ jobs:
       - run:
           command: make lint
           no_output_timeout: 30m
+      - run: make scripts-lint
       - save_cache:
           name: save go lint cache
           key: infraops-build-go-lint-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-lint-version" }}-{{ checksum ".source-key" }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ targets and README-documented workflows before running them directly.
 ## CI
 
 - CircleCI setup config uses path filtering to enable area workflows.
-- The main `build` job runs `make lint`, `make build-bump`, `make build-format`, `make api-lint`, `make api-breaking`, `make sec`, `make specs`, `make coverage`, and Codecov upload.
+- The main `build` job runs `make lint`, `make scripts-lint`, `make build-bump`, `make build-format`, `make api-lint`, `make api-breaking`, `make sec`, `make specs`, `make coverage`, and Codecov upload.
 - Area preview jobs run on non-`master`; update jobs run only on `master`.
 - Apps updates also run `make -C area/apps verify`, `load`, and `lint`.
 - Non-`master` workflows run `sync` after build and applicable previews.

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ pulumi-refresh:
 api-lint:
 	@make -C api lint
 
+# Lint repository shell workflow helpers.
+scripts-lint:
+	@shellcheck area/apps/release
+
 # Check the API for breaking changes.
 api-breaking:
 	@make -C api breaking

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Development and CI-style commands use:
 - `buf` for protobuf linting, breaking-change checks, and code generation
 - `fieldalignment` for `make lint`
 - `golangci-lint` for `make lint` when installed in `PATH`
+- `shellcheck` for `make scripts-lint`
 - `gotestsum` for `make specs`
 - `govulncheck` and Trivy for `make sec`
 
@@ -198,7 +199,8 @@ From the repository root:
 
 ```bash
 make dep          # download/tidy/vendor deps
-make lint         # lint (including field alignment)
+make lint         # lint Go sources (including field alignment)
+make scripts-lint # lint repository shell workflow helpers
 make sec          # govulncheck + Trivy
 make specs        # gotestsum + go test (junit/coverage under test/reports)
 make coverage     # HTML + function coverage under test/reports

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,1 +1,2 @@
+include ../bin/build/make/help.mak
 include ../bin/build/make/buf.mak

--- a/area/apps/Makefile
+++ b/area/apps/Makefile
@@ -1,3 +1,4 @@
+include ../../bin/build/make/help.mak
 include lean.mk
 
 # Run kube score.

--- a/area/k8s/Makefile
+++ b/area/k8s/Makefile
@@ -1,3 +1,5 @@
+include ../../bin/build/make/help.mak
+
 # Save kubeconfig.
 save-config:
 	@doctl kubernetes cluster kubeconfig save e18082d3-d874-4e84-8703-c15e6d6fea3a


### PR DESCRIPTION
## What

- Add shared help wiring to documented `api`, `area/apps`, and `area/k8s` sub-Makefiles.
- Add a `scripts-lint` target for the apps release helper and run it in the main CircleCI build.
- Update repository guidance and README tooling notes for the new shell lint surface.

## Why

- The subdirectory workflows are documented entrypoints but did not expose local help discovery.
- The apps release helper is CI-used shell workflow plumbing, so linting it closes a validation gap outside the shared Go/API checks.

## Testing

- `gmake -C api help` - passed.
- `gmake -C area/apps help` - passed.
- `gmake -C area/k8s help` - passed.
- `gmake scripts-lint` - passed.
