### PR TITLE
feat(gh): use supported collaborator permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,7 +578,7 @@ configurable in HJSON.
 
 ##### 👥 Collaborators
 
-When enabled, collaborator management grants `admin` permission to `lean-thoughts-ci`
+When enabled, collaborator management grants `push` permission to `lean-thoughts-ci`
 on `alexfalkowski/<repository>`.
 
 First change:

--- a/api/infraops/v2/service.pb.go
+++ b/api/infraops/v2/service.pb.go
@@ -312,7 +312,7 @@ func (x *Kubernetes) GetApplications() []*Application {
 
 // Collaborators toggles whether repository collaborators are managed for a repository.
 //
-// When enabled, the infra code grants "admin" permission to "lean-thoughts-ci" on
+// When enabled, the infra code grants "push" permission to "lean-thoughts-ci" on
 // "alexfalkowski/<repository>".
 type Collaborators struct {
 	state protoimpl.MessageState `protogen:"open.v1"`

--- a/api/infraops/v2/service.proto
+++ b/api/infraops/v2/service.proto
@@ -114,7 +114,7 @@ message Kubernetes {
 
 // Collaborators toggles whether repository collaborators are managed for a repository.
 //
-// When enabled, the infra code grants "admin" permission to "lean-thoughts-ci" on
+// When enabled, the infra code grants "push" permission to "lean-thoughts-ci" on
 // "alexfalkowski/<repository>".
 message Collaborators {
   // Enabled controls whether collaborator resources should be created/managed.

--- a/internal/gh/collaborator.go
+++ b/internal/gh/collaborator.go
@@ -7,7 +7,7 @@ import (
 
 // collaborator provisions a GitHub repository collaborator when collaborator management is enabled.
 //
-// The current implementation grants "admin" permissions to the "lean-thoughts-ci" user for the
+// The current implementation grants "push" permissions to the "lean-thoughts-ci" user for the
 // repository identified by repo.Name under the "alexfalkowski" owner.
 func collaborator(ctx *pulumi.Context, repo *Repository) error {
 	if !repo.HasCollaborators() {
@@ -15,7 +15,8 @@ func collaborator(ctx *pulumi.Context, repo *Repository) error {
 	}
 
 	args := &github.RepositoryCollaboratorArgs{
-		Permission: pulumi.String("admin"),
+		// GitHub personal repositories only support "push" for collaborators.
+		Permission: pulumi.String("push"),
 		Repository: pulumi.String("alexfalkowski/" + repo.Name),
 		Username:   pulumi.String("lean-thoughts-ci"),
 	}

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -132,10 +132,10 @@ type (
 
 	// Collaborators describes whether collaborator management is enabled for a repository.
 	//
-	// When enabled, the implementation grants admin permission to lean-thoughts-ci on
+	// When enabled, the implementation grants push permission to lean-thoughts-ci on
 	// alexfalkowski/<repository>.
 	Collaborators struct {
-		// Enabled controls whether the fixed admin collaborator should be managed for the repository.
+		// Enabled controls whether the fixed push collaborator should be managed for the repository.
 		Enabled bool
 	}
 
@@ -151,7 +151,7 @@ type (
 // Repository describes a GitHub repository and its desired configuration.
 type Repository struct {
 	// Collaborators is optional; when nil or disabled, collaborator resources are not managed.
-	// When enabled, lean-thoughts-ci is granted admin permission on alexfalkowski/<repository>.
+	// When enabled, lean-thoughts-ci is granted push permission on alexfalkowski/<repository>.
 	Collaborators *Collaborators
 	// Template is optional; when set, it identifies the template repository used on creation.
 	Template *Template

--- a/internal/gh/gh_test.go
+++ b/internal/gh/gh_test.go
@@ -182,7 +182,7 @@ func requireCollaborator(t *testing.T, collaborators []resource.PropertyMap) {
 	require.Len(t, collaborators, 1)
 
 	collaborator := collaborators[0]
-	require.Equal(t, "admin", test.Property(t, collaborator, "permission").StringValue())
+	require.Equal(t, "push", test.Property(t, collaborator, "permission").StringValue())
 	require.Equal(t, "alexfalkowski/test", test.Property(t, collaborator, "repository").StringValue())
 	require.Equal(t, "lean-thoughts-ci", test.Property(t, collaborator, "username").StringValue())
 }


### PR DESCRIPTION
## What

- Change the fixed GitHub repository collaborator permission from `admin` to `push` for `lean-thoughts-ci`.
- Document the personal-repository permission constraint at the assignment site.
- Align README, protobuf contract comments, generated Go, and the existing GitHub resource assertion with the emitted permission.

## Why

- GitHub personal repositories only support `push` for collaborators, so emitting `admin` can block GitHub-area Pulumi previews or updates for repositories with collaborator management enabled.
- Keeping the schema comments, generated docs, README, and test expectation aligned prevents the invalid permission from being reintroduced.

## Testing

- `go test -mod=vendor -count=1 -timeout=120s ./internal/gh ./area/gh` - passed
- `make api-lint` - passed
- `make lint` - passed
- `make specs` - passed
