### PR TITLE
feat(apps): bound verify requests

### DIFF
--- a/area/apps/release
+++ b/area/apps/release
@@ -10,6 +10,8 @@ readonly LOAD_DURATION="30s"
 readonly LOAD_SUCCESS_RATIO="1"
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+readonly VERIFY_CONNECT_TIMEOUT="5"
+readonly VERIFY_MAX_TIME="30"
 readonly -a APPS=(standort bezeichner web)
 
 # Prints command usage.
@@ -326,6 +328,8 @@ verify_all() {
 # Verifies standort.
 verify_standort() {
   curl -svf \
+    --connect-timeout "$VERIFY_CONNECT_TIMEOUT" \
+    --max-time "$VERIFY_MAX_TIME" \
     --header "Content-Type: application/json" \
     --request POST \
     --data "{}" \
@@ -335,6 +339,8 @@ verify_standort() {
 # Verifies bezeichner.
 verify_bezeichner() {
   curl -svf \
+    --connect-timeout "$VERIFY_CONNECT_TIMEOUT" \
+    --max-time "$VERIFY_MAX_TIME" \
     --header "Content-Type: application/json" \
     --request POST \
     --data '{ "application": "ulid", "count": 10 }' \
@@ -343,7 +349,10 @@ verify_bezeichner() {
 
 # Verifies web.
 verify_web() {
-  curl -svf https://web.lean-thoughts.com
+  curl -svf \
+    --connect-timeout "$VERIFY_CONNECT_TIMEOUT" \
+    --max-time "$VERIFY_MAX_TIME" \
+    https://web.lean-thoughts.com
 }
 
 # Verifies targeted release apps and falls back to the full apps verify target.


### PR DESCRIPTION
## What

- Add shared connect and total timeout constants for release verification requests.
- Apply the bounded curl options to standort, bezeichner, and web verify checks.
- Keep the existing verify endpoints and dry-run dispatch behavior unchanged.

## Why

- The post-deploy verify gate previously relied on unbounded `curl -svf` calls, so a slow or half-open endpoint could strand the serialized apps update workflow.
- Bounded curl timing gives the release helper a predictable failure window while still surfacing verification failures through curl.

## Testing

- `make scripts-lint` - passed
- `APPS_RELEASE_DRY_RUN=true ./area/apps/release verify` - passed
- Static verify block check confirmed all verify functions use both timeout flags.
- Live `make -C area/apps verify` was not run because it targets production endpoints.
