### PR TITLE
feat(apps): fail closed on live scoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ api-lint:
 
 # Lint repository shell workflow helpers.
 scripts-lint:
-	@shellcheck area/apps/release
+	@shellcheck area/apps/release area/apps/kube-score-live
 
 # Check the API for breaking changes.
 api-breaking:

--- a/area/apps/kube-score-live
+++ b/area/apps/kube-score-live
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Scores live Kubernetes resources in a namespace and fails on empty discovery.
+
+readonly KUBE_SCORE_IGNORE_TEST="deployment-has-host-podantiaffinity"
+
+# Prints command usage.
+usage() {
+  printf 'Usage: %s <namespace>\n' "$0" >&2
+}
+
+# Prints namespaced Kubernetes API resources.
+resource_names() {
+  kubectl api-resources --verbs=list --namespaced -o name
+}
+
+# Prints Kubernetes manifests for the discovered resources in a namespace.
+resource_manifests() {
+  local manifest
+  local namespace
+  local resource
+
+  namespace="$1"
+  while IFS= read -r resource; do
+    [[ -z "$resource" ]] && continue
+
+    manifest="$(kubectl get "$resource" --namespace "$namespace" -oyaml)"
+    if [[ -n "$manifest" ]]; then
+      printf '%s\n---\n' "$manifest"
+    fi
+  done
+}
+
+# Runs kube-score for a namespace.
+score_namespace() {
+  local manifests
+  local namespace
+  local resources
+
+  namespace="$1"
+  resources="$(resource_names)"
+  if [[ -z "$resources" ]]; then
+    printf 'kubectl discovery returned no namespaced resources\n' >&2
+    return 1
+  fi
+
+  manifests="$(resource_manifests "$namespace" <<< "$resources")"
+  if [[ -z "$manifests" ]]; then
+    printf 'kubectl returned no manifests for namespace %s\n' "$namespace" >&2
+    return 1
+  fi
+
+  printf '%s\n' "$manifests" \
+    | kube-score score --ignore-test "$KUBE_SCORE_IGNORE_TEST" -
+}
+
+if (($# != 1)); then
+  usage
+  exit 2
+fi
+
+score_namespace "$1"

--- a/area/apps/lean.mk
+++ b/area/apps/lean.mk
@@ -1,8 +1,6 @@
 # Run kube-score for lean.
 kube-score-lean:
-	@kubectl api-resources --verbs=list --namespaced -o name \
-		| xargs -I{} bash -c "kubectl get {} --namespace lean -oyaml && echo ---" \
-		| kube-score score --ignore-test deployment-has-host-podantiaffinity  -
+	@./kube-score-live lean
 
 # Run kubescape for lean.
 kubescape-lean:


### PR DESCRIPTION
## What

- Add an executable live kube-score helper for the apps namespace scan.
- Make `make -C area/apps kube-score` fail when Kubernetes discovery fails, returns no namespaced resources, or produces no manifests.
- Keep the Make recipe as a short wrapper and include the new helper in `make scripts-lint`.

## Why

- The previous Make pipeline could exit successfully after empty Kubernetes discovery, allowing the post-deploy apps lint gate to pass without scoring live resources.
- Failing closed gives the apps update workflow a clearer signal when the cluster cannot be discovered or no live resources are available to scan.

## Testing

- `make dep` - passed
- `make scripts-lint` - passed
- `env PATH="/private/tmp/rel3-kube-score-red:$PATH" make -C area/apps kube-score` - failed as expected for failing discovery
- `env PATH="/private/tmp/rel3-kube-score-empty:$PATH" make -C area/apps kube-score` - failed as expected for empty discovery
- `env PATH="/private/tmp/rel3-kube-score-empty-manifest:$PATH" make -C area/apps kube-score` - failed as expected for empty manifests
- `env PATH="/private/tmp/rel3-kube-score-green:$PATH" make -C area/apps kube-score` - passed
- Live `make -C area/apps lint` was not run because it needs a configured Kubernetes cluster.
