### PR TITLE
feat(bump): clarify infrastructure docs and helper usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,23 +6,23 @@ include bin/build/make/git.mak
 pulumi-login:
 	@pulumi login --cloud-url https://api.pulumi.com
 
-# Preview Pulumi changes.
+# Preview Pulumi changes (requires area=apps|cf|do|gh).
 pulumi-preview:
 	@pulumi preview --stack alexfalkowski/$(area)/prod --cwd area/$(area) --diff
 
-# Update Pulumi changes.
+# Update Pulumi changes (requires area=apps|cf|do|gh).
 pulumi-update:
 	@pulumi update --yes --stack alexfalkowski/$(area)/prod --cwd area/$(area)
 
-# Cancel Pulumi changes.
+# Cancel Pulumi changes (requires area=apps|cf|do|gh).
 pulumi-cancel:
 	@pulumi cancel --yes --stack alexfalkowski/$(area)/prod --cwd area/$(area)
 
-# Delete Pulumi stack.
+# Delete Pulumi stack (requires area=apps|cf|do|gh).
 pulumi-delete:
 	@pulumi stack rm --yes --force --stack alexfalkowski/$(area)/prod --cwd area/$(area)
 
-# Refresh Pulumi stack.
+# Refresh Pulumi stack (requires area=apps|cf|do|gh).
 pulumi-refresh:
 	@pulumi refresh --yes --stack alexfalkowski/$(area)/prod --cwd area/$(area)
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Shared implementation lives under `internal/` (e.g. `internal/app`, `internal/cf
 
 Development and CI-style commands use:
 
-- Go (version from `go.mod`: `1.25.8`)
+- Go (version declared in `go.mod`)
 - `make`
 - Ruby, used by shared lint helpers under `bin/`
 - Pulumi CLI
@@ -303,6 +303,11 @@ Only applications listed in `area/apps/apps.hjson` are deployed. The tracked fil
 `area/apps/fiction/` are example app configs and are not used unless a matching app entry references
 that namespace/name.
 
+Adding an application to `apps.hjson` only wires the Pulumi resources. To include it in release
+rollout, verify, and load workflows, also update `area/apps/release` with the app name and its
+per-app rollout, verify, and load commands, including any request payload fixture needed by load
+testing.
+
 #### 🏗️ Install / Setup
 
 Save the cluster kubeconfig if your local context is not already configured:
@@ -328,6 +333,11 @@ make area=apps pulumi-update
 The default `rollout`, `verify`, and `load` helper targets are release-aware. They inspect the app
 release diff and target only apps with version-only changes in `area/apps/apps.hjson`; when the diff
 is not a release-only app change, they fall back to all supported apps.
+
+Supported apps are the apps explicitly wired in `area/apps/release`. The `verify` helpers use
+fail-fast `curl` requests with bounded connection and total request time, and the `load` helpers run
+Vegeta and fail unless every request succeeds. Load request payloads live with the app fixtures under
+`area/apps/<namespace>/`.
 
 The release helper compares `APPS_RELEASE_BASE` to `APPS_RELEASE_HEAD` when those environment
 variables are set. Otherwise it uses the current commit's parent, falling back to `origin/master`
@@ -362,7 +372,9 @@ cd area/apps
 ```
 
 The `lint` target reads live resources from the `lean` namespace and scans them with kube-score and
-kubescape; it requires a working cluster context.
+kubescape; it requires a working cluster context. The kube-score helper intentionally ignores the
+host pod anti-affinity check and fails when Kubernetes discovery or manifest collection returns no
+live resources.
 
 #### 🗑️ Delete
 
@@ -385,13 +397,13 @@ Update a single app version in config. This is an internal helper used by automa
 `-v` value is expected to be a semantic version:
 
 ```bash
-./bump -n bezeichner -v 1.559.0
+./bump -n bezeichner -v <version>
 ```
 
 By default it edits `area/apps/apps.hjson`. Override path:
 
 ```bash
-./bump -n bezeichner -v 1.559.0 -p area/apps/apps.hjson
+./bump -n bezeichner -v <version> -p area/apps/apps.hjson
 ```
 
 > [!TIP]
@@ -409,9 +421,13 @@ Config:
 
 #### 🌐 Zone Models
 
+The shared Cloudflare zone baseline enables HTTPS, the code-defined minimum TLS setting, aggressive
+caching, HTTP/3, and HTTP/2 prioritization, disables email obfuscation, and applies the SSL mode for
+the zone model.
+
 `balancer_zones` create a Cloudflare zone plus proxied A and AAAA records for each configured
-`record_names` entry under the zone domain. Balancer zones use the shared Cloudflare zone baseline
-with SSL mode `full`.
+`record_names` entry under the zone domain. Balancer zones use the shared baseline with SSL mode
+`full`.
 
 ```hjson
 balancer_zones: [
@@ -429,7 +445,7 @@ balancer_zones: [
 ```
 
 `page_zones` create a Cloudflare zone plus a proxied `www.<domain>` CNAME to `host`. Page zones use
-the shared Cloudflare zone baseline with SSL mode `strict`.
+the shared baseline with SSL mode `strict`.
 
 ```hjson
 page_zones: [
@@ -443,7 +459,8 @@ page_zones: [
 
 #### 🪣 R2 Buckets
 
-R2 buckets are optional. A bucket with a custom domain uses this shape:
+R2 buckets are optional. Omit `zone` to create only the bucket. Include `zone` to create an enabled
+R2 custom domain using the code-defined TLS minimum:
 
 ```hjson
 buckets: [
@@ -537,6 +554,19 @@ and rebase merges are disabled, squash merge, auto-merge, update branch, auto-in
 on merge, issues, projects, wiki, secret scanning, push protection, and vulnerability alerts are
 enabled, and web commit signoff is disabled. These settings are intentional and are not configurable
 in HJSON.
+
+#### 🧬 Repository Templates
+
+`template` creates a repository from another GitHub template repository and requires both `owner` and
+`repository`. `is_template` is separate: it marks the resulting repository as a reusable template.
+
+```hjson
+is_template: true
+template: {
+  owner: alexfalkowski
+  repository: go-service-template
+}
+```
 
 #### 🛡️ Branch Protection Baseline
 

--- a/area/k8s/Makefile
+++ b/area/k8s/Makefile
@@ -8,7 +8,7 @@ save-config:
 delete:
 	@kubectl delete namespaces nginx-ingress circleci metrics-server
 
-# Set up Helm repos and install add-ons.
+# Set up Helm repos and install add-ons (requires CIRCLECI_K8S_TOKEN).
 setup: setup-helm install-helm
 
 # Set up Helm repos.
@@ -18,7 +18,7 @@ setup-helm:
 	@helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
 	@helm repo update
 
-# Install CircleCI. This target is run manually from an operator workstation, not CI.
+# Install CircleCI release agent (requires CIRCLECI_K8S_TOKEN).
 install-circleci:
 	@helm upgrade --install circleci-release circleci/circleci-release-agent --set tokenSecret.token=$(CIRCLECI_K8S_TOKEN) --create-namespace --namespace circleci --set managedNamespaces="{lean}" --set rbac.clusterRoles=false --version 1.6.2 --wait --timeout 5m
 

--- a/cmd/bump/bump.go
+++ b/cmd/bump/bump.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"errors"
 	"flag"
+	"fmt"
 	"os"
 
 	"github.com/alexfalkowski/infraops/v2/internal/app/version"
@@ -17,11 +19,27 @@ func run() error {
 	)
 
 	set := flag.NewFlagSet("bump", flag.ContinueOnError)
-	set.StringVar(&name, "n", "", "application name")
-	set.StringVar(&ver, "v", "", "application version")
-	set.StringVar(&path, "p", "", "config file path")
+	set.Usage = func() {
+		fmt.Fprintf(set.Output(), "Usage: %s -n <appName> -v <version> [-p <path>]\n\n", set.Name())
+		fmt.Fprintln(set.Output(), "Updates an application version in place.")
+		fmt.Fprintln(set.Output(), "By default, the path is area/apps/apps.hjson.")
+		fmt.Fprintln(set.Output(), "The version is written exactly as provided and is expected to be semantic.")
+		fmt.Fprintln(set.Output(), "\nFlags:")
+		set.PrintDefaults()
+	}
+	set.StringVar(&name, "n", "", "application name (required)")
+	set.StringVar(&ver, "v", "", "application version (required)")
+	set.StringVar(&path, "p", "", "config file path (default area/apps/apps.hjson)")
 	if err := set.Parse(os.Args[1:]); err != nil {
 		return err
+	}
+
+	if name == "" {
+		return errors.New("application name is required")
+	}
+
+	if ver == "" {
+		return errors.New("application version is required")
 	}
 
 	if len(path) == 0 {
@@ -39,6 +57,10 @@ func main() {
 	logger := log.NewLogger()
 
 	if err := run(); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return
+		}
+
 		logger.Error("could not bump version", "error", err)
 		os.Exit(1)
 	}

--- a/cmd/bump/doc.go
+++ b/cmd/bump/doc.go
@@ -2,7 +2,7 @@
 //
 // By default it edits `area/apps/apps.hjson`, but you can override the location via `-p`.
 // The tool is intended for internal automation and expects `-v` to be a semantic version string
-// supplied by that automation.
+// supplied by that automation. The value is written exactly as provided.
 //
 // Usage:
 //

--- a/cmd/format/format.go
+++ b/cmd/format/format.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -30,7 +31,14 @@ func run() error {
 	)
 
 	set := flag.NewFlagSet("format", flag.ContinueOnError)
-	set.StringVar(&kind, "k", "", "config kind (apps|cf|do|gh)")
+	set.Usage = func() {
+		fmt.Fprintf(set.Output(), "Usage: %s -k <apps|cf|do|gh> [-p <path>]\n\n", set.Name())
+		fmt.Fprintln(set.Output(), "Normalizes an area HJSON configuration file in place.")
+		fmt.Fprintln(set.Output(), "By default, the path is area/<kind>/<kind>.hjson.")
+		fmt.Fprintln(set.Output(), "\nFlags:")
+		set.PrintDefaults()
+	}
+	set.StringVar(&kind, "k", "", "config kind (apps|cf|do|gh) (required)")
 	set.StringVar(&path, "p", "", "config file path (default area/<kind>/<kind>.hjson)")
 	if err := set.Parse(os.Args[1:]); err != nil {
 		return err
@@ -60,6 +68,10 @@ func main() {
 	logger := log.NewLogger()
 
 	if err := run(); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return
+		}
+
 		logger.Error("could not format config", "error", err)
 		os.Exit(1)
 	}

--- a/internal/app/version/version.go
+++ b/internal/app/version/version.go
@@ -14,7 +14,8 @@ var ErrNotFound = errors.New("name not found")
 // Update sets the version for the application identified by name in the configuration at path.
 //
 // The configuration is loaded using app.ReadConfiguration and persisted using app.WriteConfiguration.
-// If no application matches name, Update returns ErrNotFound.
+// If no application matches name, Update returns ErrNotFound. The version value is written exactly as
+// provided; callers that expose this outside trusted automation should validate it before calling.
 func Update(name, version, path string) error {
 	config, err := app.ReadConfiguration(path)
 	if err != nil {


### PR DESCRIPTION
## What

- Expand README operator guidance for app release helpers, Cloudflare zone and R2 behavior, GitHub templates, and toolchain version ownership.
- Update Make help comments for Pulumi area selection and k8s CircleCI token requirements.
- Improve helper CLI help for config formatting and application version updates, including normal help exits and required app/version flags.

## Why

- The documentation gap pass found places where readers had to inspect implementation to understand release helper coverage, provider side effects, command requirements, and helper mutation behavior.
- Keeping exact versions out of README reduces stale guidance while still pointing to owning files.

## Testing

- `make dep` - passed
- `go run ./cmd/bump -h` - passed
- `go run ./cmd/bump -n bezeichner` - returned the expected required-version error
- `go run ./cmd/format -h` - passed
- `make help` - passed
- `make -C area/k8s help` - passed
- `go test ./internal/app/version` - passed
- `make build-bump` - passed
- `make build-format` - passed
- `make lint` - passed
- `make specs` - passed
- `git diff --check` - passed
