### PR TITLE
feat(apps): configure deployment replica counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,21 @@ env_vars: [
 
 Unknown values fall back to `"small"`.
 
+#### 🔢 `Application.replicas` Pod Count (apps)
+
+Always set `replicas` explicitly; there is no fallback to three. Because this is a plain proto3
+scalar, omission decodes to zero. Use `replicas: 0` explicitly when the application should run no pods.
+Canonical rewrites by the format or bump tool may omit an explicit zero; that does not change the
+deployed replica count.
+
+```hjson
+replicas: 3
+```
+
+> [!WARNING]
+> `replicas: 1` is valid, but the current rolling update and PodDisruptionBudget both allow one
+> unavailable pod, so it does not guarantee continuous availability during disruption or rollout.
+
 #### 🛡️ App NetworkPolicy Baseline
 
 The apps Pulumi program creates a `NetworkPolicy` that selects each app's pods. Ingress is limited

--- a/api/infraops/v2/service.pb.go
+++ b/api/infraops/v2/service.pb.go
@@ -157,7 +157,11 @@ type Application struct {
 	// "/etc/secrets/<secretName>".
 	Secrets []string `protobuf:"bytes,8,rep,name=secrets,proto3" json:"secrets,omitempty"`
 	// EnvVars is the list of environment variables to inject into the application container.
-	EnvVars       []*EnvVar `protobuf:"bytes,9,rep,name=env_vars,json=envVars,proto3" json:"env_vars,omitempty"`
+	EnvVars []*EnvVar `protobuf:"bytes,9,rep,name=env_vars,json=envVars,proto3" json:"env_vars,omitempty"`
+	// Replicas is the fixed number of application pods to run.
+	// State the intended value explicitly in source configuration. Zero and omission both run no pods;
+	// canonical rewrites may omit zero, and there is no fallback to three.
+	Replicas      int32 `protobuf:"varint,10,opt,name=replicas,proto3" json:"replicas,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -253,6 +257,13 @@ func (x *Application) GetEnvVars() []*EnvVar {
 		return x.EnvVars
 	}
 	return nil
+}
+
+func (x *Application) GetReplicas() int32 {
+	if x != nil {
+		return x.Replicas
+	}
+	return 0
 }
 
 // Kubernetes is the top-level configuration for the `area/apps` Pulumi program.
@@ -1167,7 +1178,7 @@ const file_infraops_v2_service_proto_rawDesc = "" +
 	"\x19infraops/v2/service.proto\x12\vinfraops.v2\"2\n" +
 	"\x06EnvVar\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value\"\xfb\x01\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value\"\x97\x02\n" +
 	"\vApplication\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04kind\x18\x02 \x01(\tR\x04kind\x12\x12\n" +
@@ -1177,7 +1188,9 @@ const file_infraops_v2_service_proto_rawDesc = "" +
 	"\aversion\x18\x06 \x01(\tR\aversion\x12\x1a\n" +
 	"\bresource\x18\a \x01(\tR\bresource\x12\x18\n" +
 	"\asecrets\x18\b \x03(\tR\asecrets\x12.\n" +
-	"\benv_vars\x18\t \x03(\v2\x13.infraops.v2.EnvVarR\aenvVars\"d\n" +
+	"\benv_vars\x18\t \x03(\v2\x13.infraops.v2.EnvVarR\aenvVars\x12\x1a\n" +
+	"\breplicas\x18\n" +
+	" \x01(\x05R\breplicas\"d\n" +
 	"\n" +
 	"Kubernetes\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12<\n" +

--- a/api/infraops/v2/service.proto
+++ b/api/infraops/v2/service.proto
@@ -101,6 +101,11 @@ message Application {
 
   // EnvVars is the list of environment variables to inject into the application container.
   repeated EnvVar env_vars = 9;
+
+  // Replicas is the fixed number of application pods to run.
+  // State the intended value explicitly in source configuration. Zero and omission both run no pods;
+  // canonical rewrites may omit zero, and there is no fallback to three.
+  int32 replicas = 10;
 }
 
 // Kubernetes is the top-level configuration for the `area/apps` Pulumi program.

--- a/area/apps/apps.hjson
+++ b/area/apps/apps.hjson
@@ -9,6 +9,7 @@
       domain: lean-thoughts.com
       version: 1.914.0
       resource: small
+      replicas: 3
     }
     {
       id: 28c679dc-5924-47e8-ac48-73cd842ba5cd
@@ -18,6 +19,7 @@
       domain: lean-thoughts.com
       version: 2.913.0
       resource: small
+      replicas: 3
     }
     {
       id: b46608ae-950a-46bb-b37a-4dfe68a95b52
@@ -27,6 +29,7 @@
       domain: lean-thoughts.com
       version: 1.477.0
       resource: small
+      replicas: 3
     }
   ]
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -44,6 +44,7 @@ func ConvertApplication(a *v2.Application) *App {
 		Namespace: a.GetNamespace(),
 		Domain:    a.GetDomain(),
 		Version:   a.GetVersion(),
+		Replicas:  a.GetReplicas(),
 		Resources: resources.Resources(a.GetResource()),
 		Secrets:   a.GetSecrets(),
 	}
@@ -109,6 +110,8 @@ type App struct {
 	Secrets []string
 	// EnvVars are environment variables to be injected into the application container.
 	EnvVars []*EnvVar
+	// Replicas is the fixed number of application pods to run. Zero runs no pods.
+	Replicas int32
 }
 
 // HasResources reports whether the application has resource requirements configured.

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -87,6 +87,26 @@ func TestApplicationReturnsResourceErrors(t *testing.T) {
 	}
 }
 
+func TestApplicationAllowsExplicitZeroReplicas(t *testing.T) {
+	stub := &test.ResourceStub{}
+	application := app.ConvertApplication(&v2.Application{
+		Kind:      "external",
+		Name:      "test",
+		Namespace: "test",
+		Domain:    "test.com",
+		Version:   "1.0.0",
+		Replicas:  0,
+	})
+
+	run := func(ctx *pulumi.Context) error {
+		return app.CreateApplication(ctx, application)
+	}
+
+	require.NoError(t, pulumi.RunErr(run, pulumi.WithMocks("project", "stack", stub)))
+	deployment := resourceOf(t, stub, deploymentResourceType)
+	require.Zero(t, test.Property(t, deploymentSpec(deployment), "replicas").NumberValue())
+}
+
 func TestApplicationReturnsMissingConfigError(t *testing.T) {
 	stub := &test.ResourceStub{}
 	application := appWithResources()
@@ -112,6 +132,7 @@ func TestConvertedApplicationDeploymentInputs(t *testing.T) {
 		Domain:    "test.com",
 		Version:   "1.0.0",
 		Resource:  "unknown",
+		Replicas:  4,
 		Secrets:   []string{"database"},
 		EnvVars: []*v2.EnvVar{
 			{Name: "LOG_LEVEL", Value: "info"},
@@ -131,6 +152,7 @@ func TestConvertedApplicationDeploymentInputs(t *testing.T) {
 	require.Equal(t, "1Gi", resourceRequest(deployment, "ephemeral-storage"))
 	require.Equal(t, "2Gi", resourceLimit(deployment, "ephemeral-storage"))
 	require.Equal(t, "RuntimeDefault", seccompProfileType(deployment))
+	require.Equal(t, 4, int(test.Property(t, deploymentSpec(deployment), "replicas").NumberValue()))
 
 	secret := envVar(deployment, "DATABASE_PASSWORD")
 	valueFrom := test.Property(t, secret, "valueFrom").ObjectValue()
@@ -149,6 +171,7 @@ func TestExternalApplicationOmitsInternalResources(t *testing.T) {
 		Domain:    "test.com",
 		Version:   "1.0.0",
 		Resource:  "small",
+		Replicas:  1,
 	})
 	run := func(ctx *pulumi.Context) error {
 		return app.CreateApplication(ctx, application)
@@ -173,6 +196,7 @@ func appWithResources() *app.App {
 		Namespace: "test",
 		Domain:    "test.com",
 		Version:   "1.0.0",
+		Replicas:  3,
 		Secrets:   []string{"test"},
 		Resources: &app.Resources{
 			CPU:     &app.Range{Min: "125m", Max: "250m"},
@@ -192,6 +216,7 @@ func appWithoutResources() *app.App {
 		Namespace: "test",
 		Domain:    "test.com",
 		Version:   "1.0.0",
+		Replicas:  3,
 		Secrets:   []string{"test"},
 		EnvVars: []*app.EnvVar{
 			{Name: "test", Value: "test"},

--- a/internal/app/deployment.go
+++ b/internal/app/deployment.go
@@ -15,7 +15,7 @@ func createDeployment(ctx *pulumi.Context, app *App) error {
 		Metadata: m,
 		Spec: av1.DeploymentSpecArgs{
 			Selector: mv1.LabelSelectorArgs{MatchLabels: matchLabels(app)},
-			Replicas: pulumi.Int(3),
+			Replicas: pulumi.Int(int(app.Replicas)),
 			Strategy: av1.DeploymentStrategyArgs{
 				RollingUpdate: av1.RollingUpdateDeploymentArgs{
 					MaxSurge:       inputs.One,

--- a/internal/app/test/apps.hjson
+++ b/internal/app/test/apps.hjson
@@ -4,10 +4,12 @@
     {
       name: app1
       version: 1.1.0
+      replicas: 3
     }
     {
       name: app2
       version: 1.0.0
+      replicas: 3
     }
   ]
 }

--- a/internal/app/version/version_test.go
+++ b/internal/app/version/version_test.go
@@ -22,8 +22,10 @@ func TestValidUpdate(t *testing.T) {
 	require.Len(t, applications, 2)
 	require.Equal(t, "app1", applications[0].GetName())
 	require.Equal(t, "2.0.0", applications[0].GetVersion())
+	require.EqualValues(t, 3, applications[0].GetReplicas())
 	require.Equal(t, "app2", applications[1].GetName())
 	require.Equal(t, "1.0.0", applications[1].GetVersion())
+	require.EqualValues(t, 3, applications[1].GetReplicas())
 }
 
 func TestInvalidUpdate(t *testing.T) {

--- a/internal/test/apps.hjson
+++ b/internal/test/apps.hjson
@@ -22,6 +22,7 @@
           value: "secret:database/password"
         }
       ]
+      replicas: 3
     }
     {
       id: 22222222-2222-2222-2222-222222222222
@@ -37,6 +38,7 @@
           value: enabled
         }
       ]
+      replicas: 3
     }
     {
       id: 33333333-3333-3333-3333-333333333333
@@ -51,6 +53,7 @@
           value: "https://api.example.net"
         }
       ]
+      replicas: 3
     }
   ]
 }


### PR DESCRIPTION
## What

- Add a per-application `replicas` field to the v2 configuration schema and project it directly into Kubernetes Deployments.
- Keep every tracked application at three replicas while allowing explicit zero and other fixed counts without a fallback.
- Document proto3 zero and omission behavior, canonical rewrite behavior, and the availability tradeoff for a single replica.

## Why

- Let operators control workload cardinality in source-controlled configuration without editing shared deployment code or changing current production capacity during migration.

## Testing

- `make dep` - passed
- `make api-generate` - passed
- `make lint` - passed
- `make api-lint` - passed
- `make api-breaking` - passed
- `make sec` - passed
- `make specs` - passed (60 tests)
- `make coverage` - passed (94.5% statement coverage)
- `make build-bump build-format` - passed
- Go tests cover explicit zero, a non-default replica count, and preservation through application version updates.
- Pulumi preview was not run because it requires live stack and provider credentials; CI will run the apps preview.

AI-assisted-by: [Codex](https://openai.com/codex/)
