### PR TITLE
docs(agents): document sibling repo layout and release automation for cross-repo diagnosis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,29 @@ Use `bin/AGENTS.md` for shared skills and cross-repository defaults.
 - `cmd/format`: HJSON config formatter.
 - `bin`: shared build tooling submodule.
 
+## Related Repositories
+
+- Sibling repositories owned by this org are normally checked out locally one
+  directory up, at `../<repo-name>` (for example `../bezeichner`, `../standort`,
+  `../web`, `../docker`, `../bin`), and are hosted at
+  `https://github.com/alexfalkowski/<repo-name>`. Check for a local sibling
+  checkout before treating a related repository as unavailable or reporting a
+  cross-repo data gap. If no local checkout exists, use `gh` to read the
+  repository on GitHub before reporting the gap:
+  `gh repo clone <owner>/<repo> <scratch-dir> -- --depth 1`
+  to explore multiple files, or `gh api repos/<owner>/<repo>/contents/<path>`
+  to fetch one known file directly. `<owner>` here is `alexfalkowski`, the same
+  account this repo's own `origin` remote resolves to
+  (`git@github.com:alexfalkowski/infraops.git`); sibling repos share that owner.
+- The `release(<app>): upgraded to vX.Y.Z` PRs against `area/apps/apps.hjson`
+  are opened by each app's own CircleCI pipeline (in that app's own repo), not
+  by anything in this repo. That pipeline runs the shared `alexfalkowski/release`
+  Docker image, built from `../docker/release/Dockerfile`, which installs
+  `cmd/bump` at a version pinned via `install-go-tool` rather than building it
+  fresh from this repo's current `master`. Diagnosing that automation requires
+  reading `../docker/release/Dockerfile` and `../docker/release/deploy` and the
+  app repo's `.circleci/config.yml`, not just this repo.
+
 ## Commands
 
 Run from the repo root unless noted:


### PR DESCRIPTION
## What

- Add a "Related Repositories" section to `AGENTS.md` documenting that org sibling repos (`bezeichner`, `standort`, `web`, `docker`, `bin`) are normally checked out locally as `../<repo-name>` and hosted at `github.com/alexfalkowski/<repo-name>`, with a `gh`-based clone/API fallback for when no local checkout exists.
- Document that `release(<app>): upgraded to vX.Y.Z` PRs against `area/apps/apps.hjson` are opened by each app's own CircleCI pipeline using the shared `alexfalkowski/release` Docker image (built from `../docker/release/Dockerfile`), which installs `cmd/bump` at a version pinned via `install-go-tool` rather than building it fresh from this repo's current `master`.

## Why

- A recent diagnosis of PR #3148, which silently deleted `replicas` from every app entry in `area/apps/apps.hjson`, initially reported "no access to the release automation" as a data gap, when the actual root cause was fully discoverable locally: the pinned `cmd/bump` version baked into the `docker` repo's release image lagged the schema change that added the `replicas` field, so it dropped that field from every app when it rewrote the config.
- Recording this here means future diagnosis doesn't repeat the same avoidable data gap, and the release automation's actual location and mechanics are documented durably instead of being rediscovered from scratch each time.

## Testing

- No automated validation target applies; this repo's `make lint` only covers Go code and there is no markdown/doc lint target for `AGENTS.md`.
- Manually verified the new claims against `../docker/release/Dockerfile`, `../docker/release/deploy`, the `bezeichner` repo's `.circleci/config.yml`, and this repo's own `git remote get-url origin`.
- Ran `$doc-standards` and `$code-review` against the diff; both passed with no blocking findings. Fixed one line-wrap inconsistency `$doc-standards` flagged before committing.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
