### PR TITLE
feat(format): prevent cross-area configuration rewrites

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ Override the path:
 ./format -k cf -p area/cf/cf.hjson
 ```
 
+The selected kind must match the file's area-specific fields. A mismatch is rejected
+without changing the file.
+
 ### 📝 Config Schema Notes
 
 A few conventions are implemented by the Go code and are worth knowing when editing HJSON:

--- a/cmd/format/doc.go
+++ b/cmd/format/doc.go
@@ -1,7 +1,8 @@
 // Command format normalizes/rewrites an area configuration file in a consistent HJSON form.
 //
 // It reads a configuration into the corresponding protobuf message and writes it back out
-// using the repository's canonical HJSON formatting rules.
+// using the repository's canonical HJSON formatting rules. It rejects a file whose
+// top-level area-specific fields do not match the selected kind without rewriting it.
 //
 // Usage:
 //

--- a/cmd/format/format.go
+++ b/cmd/format/format.go
@@ -9,6 +9,8 @@ import (
 	v2 "github.com/alexfalkowski/infraops/v2/api/infraops/v2"
 	"github.com/alexfalkowski/infraops/v2/internal/config"
 	"github.com/alexfalkowski/infraops/v2/internal/log"
+	"github.com/hjson/hjson-go/v4"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 // configs maps a supported config kind (as provided by the `-k` flag) to the protobuf
@@ -57,8 +59,43 @@ func run() error {
 		return err
 	}
 
+	if err := validateConfigKind(path, kind); err != nil {
+		return err
+	}
+
 	if err := config.Write(path, cfg); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// validateConfigKind prevents a config for another supported area from being rewritten with the selected schema.
+func validateConfigKind(path, kind string) error {
+	bytes, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	fields := map[string]any{}
+	if err := hjson.Unmarshal(bytes, &fields); err != nil {
+		return err
+	}
+
+	for field := range fields {
+		if field == "version" {
+			continue
+		}
+
+		for configKind, config := range configs {
+			if configKind == kind {
+				continue
+			}
+
+			if config.ProtoReflect().Descriptor().Fields().ByName(protoreflect.Name(field)) != nil {
+				return fmt.Errorf("%s: file does not match kind %q", path, kind)
+			}
+		}
 	}
 
 	return nil

--- a/cmd/format/format_test.go
+++ b/cmd/format/format_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatRejectsMismatchedConfigKind(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cf.hjson")
+	contents := []byte("{\n  version: \"2.0\"\n  balancer_zones: []\n}\n")
+	require.NoError(t, os.WriteFile(path, contents, 0o600))
+
+	args := os.Args
+	t.Cleanup(func() {
+		os.Args = args
+	})
+	os.Args = []string{"format", "-k", "apps", "-p", path}
+
+	require.Error(t, run())
+
+	actual, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, contents, actual)
+}


### PR DESCRIPTION
## What

- Reject formatter kind/path mismatches before they can rewrite a configuration file with another area’s schema.
- Document the rejection behavior and add a regression test that preserves the original file bytes.

## Why

- A mismatched `-k` and `-p` previously exited successfully after deleting all area-specific configuration, creating a source-of-truth data-loss risk.

## Testing

- `make specs package=cmd/format` - passed
- `make lint` - passed
- Full `make build-format`, `make specs`, and `make sec` were not rerun after simplifying the test to avoid restarting broad compilation during host recovery; CI will run the normal checks.

AI-assisted-by: [Codex](https://openai.com/codex/)
