### PR TITLE
feat(apps): drop all container Linux capabilities

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -161,6 +161,38 @@ func TestConvertedApplicationDeploymentInputs(t *testing.T) {
 	require.Equal(t, "password", test.Property(t, secretKeyRef, "key").StringValue())
 }
 
+func TestApplicationContainerSecurityContextDropsAllCapabilities(t *testing.T) {
+	tests := []struct {
+		app  *app.App
+		name string
+	}{
+		{app: appWithResources(), name: "internal"},
+		{
+			app: app.ConvertApplication(&v2.Application{
+				Kind:      "external",
+				Name:      "test",
+				Namespace: "test",
+				Domain:    "test.com",
+				Version:   "1.0.0",
+				Replicas:  1,
+			}),
+			name: "external",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stub := &test.ResourceStub{}
+			run := func(ctx *pulumi.Context) error {
+				return app.CreateApplication(ctx, tt.app)
+			}
+
+			require.NoError(t, pulumi.RunErr(run, pulumi.WithMocks("project", "stack", stub)))
+			require.Equal(t, []string{"ALL"}, droppedCapabilities(t, resourceOf(t, stub, deploymentResourceType)))
+		})
+	}
+}
+
 func TestExternalApplicationOmitsInternalResources(t *testing.T) {
 	stub := &test.ResourceStub{}
 	application := app.ConvertApplication(&v2.Application{
@@ -315,6 +347,14 @@ func seccompProfileType(deployment resource.PropertyMap) string {
 	security := container(deployment)[resource.PropertyKey("securityContext")].ObjectValue()
 	profile := security[resource.PropertyKey("seccompProfile")].ObjectValue()
 	return profile[resource.PropertyKey("type")].StringValue()
+}
+
+func droppedCapabilities(t *testing.T, deployment resource.PropertyMap) []string {
+	t.Helper()
+
+	security := container(deployment)[resource.PropertyKey("securityContext")].ObjectValue()
+	capabilities := test.Property(t, security, "capabilities").ObjectValue()
+	return test.StringValues(test.Property(t, capabilities, "drop").ArrayValue())
 }
 
 func deploymentSpec(deployment resource.PropertyMap) resource.PropertyMap {

--- a/internal/app/container.go
+++ b/internal/app/container.go
@@ -64,6 +64,9 @@ func containerSecurity() cv1.SecurityContextArgs {
 	return cv1.SecurityContextArgs{
 		ReadOnlyRootFilesystem:   inputs.Yes,
 		AllowPrivilegeEscalation: inputs.No,
+		Capabilities: cv1.CapabilitiesArgs{
+			Drop: pulumi.StringArray{pulumi.String("ALL")},
+		},
 		SeccompProfile: cv1.SeccompProfileArgs{
 			Type: pulumi.String("RuntimeDefault"),
 		},


### PR DESCRIPTION
## What

- Drops all Linux capabilities from the shared app container security context for both internal and external applications.
- Adds Deployment-rendering coverage that verifies `capabilities.drop: ["ALL"]` for each supported application kind.

## Why

- Application containers already use non-root execution, a read-only root filesystem, disabled privilege escalation, and the runtime-default seccomp profile; removing the runtime's default Linux capabilities completes that restricted security posture and reduces post-compromise blast radius.

## Testing

- `make package=internal/app specs` - passed; verifies rendered internal and external Deployments drop all capabilities.
- `make lint` - passed.
- `make specs` - passed.
- `make coverage` - passed, but reported 0.0% because the generated profile was empty; focused rendering coverage is verified by the package test above.
- `make sec` - passed; no reachable vulnerabilities or repository scan findings. The scanner reported an uncalled upstream `golang.org/x/crypto/openpgp` advisory with no fix.
- `make -C area/apps lint` - not run because it scans live deployed resources and cannot validate this unapplied change; future external images that require a Linux capability need runtime validation.

AI-assisted-by: [Codex](https://openai.com/codex/)
