### PR TITLE
test(format): cover cross-area configuration rejection

### DIFF
--- a/cmd/format/format_test.go
+++ b/cmd/format/format_test.go
@@ -9,19 +9,50 @@ import (
 )
 
 func TestFormatRejectsMismatchedConfigKind(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "cf.hjson")
-	contents := []byte("{\n  version: \"2.0\"\n  balancer_zones: []\n}\n")
-	require.NoError(t, os.WriteFile(path, contents, 0o600))
-
 	args := os.Args
 	t.Cleanup(func() {
 		os.Args = args
 	})
-	os.Args = []string{"format", "-k", "apps", "-p", path}
 
-	require.Error(t, run())
+	tests := []struct {
+		name     string
+		kind     string
+		contents []byte
+	}{
+		{
+			name:     "apps config as cloudflare",
+			kind:     "cf",
+			contents: []byte("{\n  version: \"2.0\"\n  applications: []\n}\n"),
+		},
+		{
+			name:     "cloudflare config as digital ocean",
+			kind:     "do",
+			contents: []byte("{\n  version: \"2.0\"\n  balancer_zones: []\n}\n"),
+		},
+		{
+			name:     "digital ocean config as github",
+			kind:     "gh",
+			contents: []byte("{\n  version: \"2.0\"\n  clusters: []\n}\n"),
+		},
+		{
+			name:     "github config as apps",
+			kind:     "apps",
+			contents: []byte("{\n  version: \"2.0\"\n  repositories: []\n}\n"),
+		},
+	}
 
-	actual, err := os.ReadFile(path)
-	require.NoError(t, err)
-	require.Equal(t, contents, actual)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.hjson")
+			require.NoError(t, os.WriteFile(path, test.contents, 0o600))
+
+			os.Args = []string{"format", "-k", test.kind, "-p", path}
+
+			require.Error(t, run())
+
+			actual, err := os.ReadFile(path)
+			require.NoError(t, err)
+			require.Equal(t, test.contents, actual)
+		})
+	}
 }


### PR DESCRIPTION
## What

- Cover cross-area configuration mismatches for all four supported schemas, verifying a rejected command leaves the input file unchanged.

## Why

- Keep the formatter's data-loss protection covered across every supported configuration kind.

## Testing

- `make specs` - passed
- `make lint` - passed
- Added table-driven cases for apps, Cloudflare, DigitalOcean, and GitHub mismatch rejection.

AI-assisted-by: [Codex](https://openai.com/codex/)
