### PR TITLE
feat(apps): target workload checks by release diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,8 +326,8 @@ Only applications listed in `area/apps/apps.hjson` are deployed. The tracked fil
 that namespace/name.
 
 Adding an application to `apps.hjson` only wires the Pulumi resources. To include it in release
-rollout, verify, and load workflows, also update `area/apps/release` with the app name and its
-per-app rollout, verify, and load commands, including any request payload fixture needed by load
+rollout, verify, load, and kubescape workflows, also update `area/apps/release` with the app name and its
+per-app helper commands, including any request payload fixture needed by load
 testing.
 
 #### 🏗️ Install / Setup
@@ -352,7 +352,7 @@ make area=apps pulumi-update
 
 #### 🧪 App Helpers
 
-The default `rollout`, `verify`, and `load` helper targets are release-aware. They inspect the app
+The default `rollout`, `verify`, `load`, and `kubescape` helper targets are release-aware. They inspect the app
 release diff and target only apps with version-only changes in `area/apps/apps.hjson`; when the diff
 is not a release-only app change, they fall back to all supported apps.
 
@@ -391,12 +391,14 @@ cd area/apps
 ./release verify-web
 ./release load-bezeichner
 ./release rollout-standort
+./release kubescape-web
 ```
 
-The `lint` target reads live resources from the `lean` namespace and scans them with kube-score and
-kubescape; it requires a working cluster context. The kube-score helper intentionally ignores the
-host pod anti-affinity check and fails when Kubernetes discovery or manifest collection returns no
-live resources.
+The `lint` target requires a working cluster context. kube-score always scans live resources from
+the `lean` namespace, while kubescape follows the release-aware workflow: it scans each changed app
+Deployment for release-only version changes and otherwise scans the whole namespace. The kube-score
+helper intentionally ignores the host pod anti-affinity check and fails when Kubernetes discovery
+or manifest collection returns no live resources.
 
 #### 🗑️ Delete
 

--- a/area/apps/Makefile
+++ b/area/apps/Makefile
@@ -5,7 +5,11 @@ include lean.mk
 kube-score: kube-score-lean
 
 # Run kubescape.
-kubescape: kubescape-lean
+kubescape:
+	@./release kubescape
+
+# Run kubescape for all apps.
+kubescape-all: kubescape-lean
 
 # Lint live app resources.
 lint: kube-score kubescape

--- a/area/apps/release
+++ b/area/apps/release
@@ -16,7 +16,7 @@ readonly -a APPS=(standort bezeichner web)
 
 # Prints command usage.
 usage() {
-  printf 'Usage: %s <halt-ci|is-release|load|load-all|load-bezeichner|load-standort|load-web|rollout|rollout-all|rollout-bezeichner|rollout-standort|rollout-web|verify|verify-all|verify-bezeichner|verify-standort|verify-web>\n' "$0" >&2
+  printf 'Usage: %s <halt-ci|is-release|kubescape|kubescape-all|kubescape-bezeichner|kubescape-standort|kubescape-web|load|load-all|load-bezeichner|load-standort|load-web|rollout|rollout-all|rollout-bezeichner|rollout-standort|rollout-web|verify|verify-all|verify-bezeichner|verify-standort|verify-web>\n' "$0" >&2
 }
 
 # Prints the revision to inspect for app release changes.
@@ -140,7 +140,7 @@ is_app() {
 # Reports whether an app action has release helper commands.
 is_action() {
   case "$1" in
-    load | rollout | verify)
+    kubescape | load | rollout | verify)
       return 0
       ;;
     *)
@@ -191,15 +191,17 @@ run_all_apps() {
   done
 }
 
-# Runs a release-aware app action and falls back to all apps.
+# Runs a release-aware app action and falls back to all apps or a supplied action.
 run_release_changes() {
   local action
   local app
   local apps=()
+  local fallback
   local label
 
   action="$1"
   label="$2"
+  fallback="${3:-}"
 
   while IFS= read -r app; do
     [[ -n "$app" ]] && apps+=("$app")
@@ -207,6 +209,11 @@ run_release_changes() {
 
   if ((${#apps[@]} == 0)); then
     printf '%s all apps.\n' "$label"
+    if [[ -n "$fallback" ]]; then
+      "$fallback"
+      return
+    fi
+
     run_all_apps "$action"
     return
   fi
@@ -295,6 +302,44 @@ load_release_changes() {
   run_release_changes "load" "Loading"
 }
 
+# Scans all apps in the namespace with kubescape.
+kubescape_all() {
+  if [[ "${APPS_RELEASE_DRY_RUN:-}" == "true" ]]; then
+    printf 'make -C %s kubescape-all\n' "$APP_MAKE_DIR"
+    return
+  fi
+
+  make -C "$REPO_ROOT/$APP_MAKE_DIR" kubescape-all
+}
+
+# Scans an app deployment with kubescape.
+kubescape_app() {
+  local app
+
+  app="$1"
+  kubescape scan workload "Deployment/$app" --namespace lean
+}
+
+# Scans a specific app with kubescape.
+kubescape_bezeichner() {
+  kubescape_app "bezeichner"
+}
+
+# Scans a specific app with kubescape.
+kubescape_standort() {
+  kubescape_app "standort"
+}
+
+# Scans a specific app with kubescape.
+kubescape_web() {
+  kubescape_app "web"
+}
+
+# Scans targeted release apps with kubescape and falls back to the namespace scan.
+kubescape_release_changes() {
+  run_release_changes "kubescape" "Scanning" "kubescape_all"
+}
+
 # Rolls out all apps.
 rollout_all() {
   run_all_apps "rollout"
@@ -380,6 +425,21 @@ case "${1:-}" in
     ;;
   is-release)
     release_apps >/dev/null
+    ;;
+  kubescape)
+    kubescape_release_changes
+    ;;
+  kubescape-all)
+    kubescape_all
+    ;;
+  kubescape-bezeichner)
+    run_app_action "kubescape" "bezeichner"
+    ;;
+  kubescape-standort)
+    run_app_action "kubescape" "standort"
+    ;;
+  kubescape-web)
+    run_app_action "kubescape" "web"
     ;;
   load)
     load_release_changes


### PR DESCRIPTION
## What

- Make kubescape release-aware: scan version-only release deployments individually and scan the full `lean` namespace for all other changes.
- Expose all-scope and per-deployment helper commands, and document the helper behavior and cluster requirement.

## Why

- Keep the live-resource lint path focused for app version releases while preserving full namespace coverage for broader changes.

## Testing

- `make dep` - passed
- `make scripts-lint` - passed
- `APPS_RELEASE_DRY_RUN=true APPS_RELEASE_BASE=HEAD^ APPS_RELEASE_HEAD=HEAD make -C area/apps kubescape` - passed; verified the release-only deployment route.
- `APPS_RELEASE_DRY_RUN=true APPS_RELEASE_BASE=HEAD APPS_RELEASE_HEAD=HEAD make -C area/apps kubescape` - passed; verified the full-namespace fallback route.

AI-assisted-by: [Codex](https://openai.com/codex/)
