### PR TITLE
feat(apps): scan deployed images with kubescape

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,9 +396,9 @@ cd area/apps
 
 The `lint` target requires a working cluster context. kube-score always scans live resources from
 the `lean` namespace, while kubescape follows the release-aware workflow: it scans each changed app
-Deployment for release-only version changes and otherwise scans the whole namespace. The kube-score
-helper intentionally ignores the host pod anti-affinity check and fails when Kubernetes discovery
-or manifest collection returns no live resources.
+Deployment and its resolved container image for release-only version changes and otherwise scans the
+whole namespace. The kube-score helper intentionally ignores the host pod anti-affinity check and
+fails when Kubernetes discovery or manifest collection returns no live resources.
 
 #### 🗑️ Delete
 

--- a/area/apps/release
+++ b/area/apps/release
@@ -315,9 +315,12 @@ kubescape_all() {
 # Scans an app deployment with kubescape.
 kubescape_app() {
   local app
+  local image
 
   app="$1"
+  image="$(kubectl get deployment "$app" --namespace lean --output jsonpath='{.spec.template.spec.containers[0].image}')"
   kubescape scan workload "Deployment/$app" --namespace lean
+  kubescape scan image "$image"
 }
 
 # Scans a specific app with kubescape.


### PR DESCRIPTION
## What

- Scan the deployed container image as well as its Deployment when the release-aware Kubescape workflow detects a version-only application update.
- Document that release-only lint performs both workload and resolved-image checks while broader changes retain the namespace scan.

## Why

- Include image vulnerability coverage in targeted release validation without expanding the normal release-only workflow to a full namespace scan.

## Testing

- `make dep` - passed
- `make scripts-lint` - passed
- `make sec` - passed; Go vulnerability and Trivy repository scans found no code-reachable vulnerabilities or repository findings.
- `git diff --check` - passed
- `make -C area/apps lint` - not run; requires the live `lean` Kubernetes context and scans the resolved registry image. The master apps-update workflow runs it.

AI-assisted-by: [Codex](https://openai.com/codex/)
